### PR TITLE
Add Spotless Maven plugin and apply import cleanup

### DIFF
--- a/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerHistoryView.java
+++ b/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerHistoryView.java
@@ -29,4 +29,3 @@ public class ControllerHistoryView {
         return recordYield;
     }
 }
-

--- a/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerTimeView.java
+++ b/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerTimeView.java
@@ -1,14 +1,14 @@
 package io.freedriver.autonomy.entity.view;
 
-import io.freedriver.victron.StateOfOperation;
-import io.freedriver.victron.vedirect.OffReason;
-
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import io.freedriver.victron.StateOfOperation;
+import io.freedriver.victron.vedirect.OffReason;
 
 public class ControllerTimeView {
     private final Map<String, Long> data;

--- a/api/src/main/java/io/freedriver/autonomy/entity/view/LithiumBatteryView.java
+++ b/api/src/main/java/io/freedriver/autonomy/entity/view/LithiumBatteryView.java
@@ -1,17 +1,17 @@
 package io.freedriver.autonomy.entity.view;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
 import io.freedriver.autonomy.jpa.entity.event.sbms.SBMSMessage;
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.types.electrical.Current;
 import io.freedriver.math.measurement.types.electrical.Potential;
 import io.freedriver.math.measurement.types.electrical.Power;
 import io.freedriver.math.number.ScaledNumber;
-
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
 
 public class LithiumBatteryView {
     private List<String> sourceIds = new ArrayList<>();

--- a/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/AllJoysticks.java
+++ b/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/AllJoysticks.java
@@ -1,8 +1,5 @@
 package io.freedriver.autonomy.event.input.joystick.jstest;
 
-import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
-import io.freedriver.autonomy.util.Delayable;
-
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashSet;
@@ -16,6 +13,9 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+
+import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
+import io.freedriver.autonomy.util.Delayable;
 
 /**
  * Single point to discover and monitor all joystick devices on a system.

--- a/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/FailedJoystick.java
+++ b/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/FailedJoystick.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.event.input.joystick.jstest;
 
+import static java.time.temporal.ChronoUnit.MINUTES;
+
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
-
-import static java.time.temporal.ChronoUnit.MINUTES;
 
 /**
  * Convenience class to keep track of joystick devices that failed to spawn readers.

--- a/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/JSTestReader.java
+++ b/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/JSTestReader.java
@@ -1,9 +1,5 @@
 package io.freedriver.autonomy.event.input.joystick.jstest;
 
-import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSMetadata;
-import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
-import io.freedriver.base.util.ProcessUtil;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -15,6 +11,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSMetadata;
+import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
+import io.freedriver.base.util.ProcessUtil;
 
 public class JSTestReader {
     private static final Logger LOGGER = Logger.getLogger(JSTestReader.class.getName());

--- a/api/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/EventApi.java
+++ b/api/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/EventApi.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy.jaxrs.endpoint;
 
-import io.freedriver.autonomy.jpa.entity.event.Event;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import io.freedriver.autonomy.jpa.entity.event.Event;
 
 @Path(EventApi.ROOT)
 @Produces(APPLICATION_JSON)

--- a/api/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/ReadApi.java
+++ b/api/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/ReadApi.java
@@ -1,8 +1,8 @@
 package io.freedriver.autonomy.jaxrs.endpoint;
 
+import java.util.stream.Stream;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import java.util.stream.Stream;
 
 public interface ReadApi<ENTITY, ID> {
     String ID_PARAMETER = "id";

--- a/api/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/SBMSApi.java
+++ b/api/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/SBMSApi.java
@@ -1,14 +1,14 @@
 package io.freedriver.autonomy.jaxrs.endpoint;
 
 
-import io.freedriver.autonomy.entity.view.LithiumBatteryView;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import io.freedriver.autonomy.entity.view.LithiumBatteryView;
 
 @Path(SBMSApi.ROOT)
 @Produces(APPLICATION_JSON)

--- a/api/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/SimpleAliasApi.java
+++ b/api/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/SimpleAliasApi.java
@@ -1,7 +1,9 @@
 package io.freedriver.autonomy.jaxrs.endpoint;
 
-import io.freedriver.autonomy.jaxrs.view.AliasView;
-
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -9,10 +11,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+
+import io.freedriver.autonomy.jaxrs.view.AliasView;
 
 @Path(SimpleAliasApi.ROOT)
 @Produces(MediaType.APPLICATION_JSON)

--- a/api/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/VEDirectApi.java
+++ b/api/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/VEDirectApi.java
@@ -1,22 +1,22 @@
 package io.freedriver.autonomy.jaxrs.endpoint;
 
-import io.freedriver.autonomy.entity.view.ControllerView;
-import io.freedriver.autonomy.exception.VEDirectApiException;
-import io.freedriver.autonomy.jpa.entity.VEDirectMessage;
-import io.freedriver.victron.VEDirectColumn;
-import io.freedriver.victron.VictronDevice;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import io.freedriver.autonomy.entity.view.ControllerView;
+import io.freedriver.autonomy.exception.VEDirectApiException;
+import io.freedriver.autonomy.jpa.entity.VEDirectMessage;
+import io.freedriver.victron.VEDirectColumn;
+import io.freedriver.victron.VictronDevice;
 
 @Path(VEDirectApi.ROOT)
 @Produces(APPLICATION_JSON)

--- a/api/src/test/java/io/freedriver/autonomy/UUIDTest.java
+++ b/api/src/test/java/io/freedriver/autonomy/UUIDTest.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class UUIDTest {
     @Test

--- a/api/src/test/java/io/freedriver/autonomy/entity/event/input/joystick/jstest/AllJoysticksTest.java
+++ b/api/src/test/java/io/freedriver/autonomy/entity/event/input/joystick/jstest/AllJoysticksTest.java
@@ -1,10 +1,6 @@
 package io.freedriver.autonomy.entity.event.input.joystick.jstest;
 
-import io.freedriver.autonomy.event.input.joystick.jstest.AllJoysticks;
-import io.freedriver.autonomy.event.input.joystick.jstest.JSTestReader;
-import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
-import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEventType;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -16,7 +12,11 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import io.freedriver.autonomy.event.input.joystick.jstest.AllJoysticks;
+import io.freedriver.autonomy.event.input.joystick.jstest.JSTestReader;
+import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
+import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEventType;
+import org.junit.jupiter.api.Test;
 
 public class AllJoysticksTest {
 

--- a/api/src/test/java/io/freedriver/autonomy/entity/math/SocRangeTest.java
+++ b/api/src/test/java/io/freedriver/autonomy/entity/math/SocRangeTest.java
@@ -1,17 +1,17 @@
 package io.freedriver.autonomy.entity.math;
 
-import io.freedriver.autonomy.jpa.entity.math.SocRange;
-import io.freedriver.autonomy.jpa.entity.math.VoltageSoc;
-import io.freedriver.math.measurement.types.electrical.Potential;
-import io.freedriver.math.number.ScaledNumber;
-import org.junit.jupiter.api.Test;
+import static io.freedriver.math.UnitPrefix.ONE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.stream.IntStream;
 
-import static io.freedriver.math.UnitPrefix.ONE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import io.freedriver.autonomy.jpa.entity.math.SocRange;
+import io.freedriver.autonomy.jpa.entity.math.VoltageSoc;
+import io.freedriver.math.measurement.types.electrical.Potential;
+import io.freedriver.math.number.ScaledNumber;
+import org.junit.jupiter.api.Test;
 
 public class SocRangeTest {
 

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/converter/event/EventActionConverter.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/converter/event/EventActionConverter.java
@@ -1,10 +1,10 @@
 package io.freedriver.autonomy.jpa.converter.event;
 
-import io.freedriver.autonomy.jpa.entity.event.EventAction;
-import io.freedriver.autonomy.jpa.util.Base64Serialization;
-
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
+
+import io.freedriver.autonomy.jpa.entity.event.EventAction;
+import io.freedriver.autonomy.jpa.util.Base64Serialization;
 
 @Converter(autoApply = true)
 public class EventActionConverter implements AttributeConverter<EventAction, String> {

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/EmbeddedEntityBase.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/EmbeddedEntityBase.java
@@ -1,8 +1,8 @@
 package io.freedriver.autonomy.jpa.entity;
 
-import io.freedriver.autonomy.jpa.iface.Positional;
-
 import java.io.Serializable;
+
+import io.freedriver.autonomy.jpa.iface.Positional;
 
 public abstract class EmbeddedEntityBase implements Serializable, Positional {
     private long position = 0;

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/EntityBase.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/EntityBase.java
@@ -1,10 +1,10 @@
 package io.freedriver.autonomy.jpa.entity;
 
+import java.io.Serializable;
+import java.util.Objects;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
-import java.io.Serializable;
-import java.util.Objects;
 
 @MappedSuperclass
 public abstract class EntityBase implements Serializable {

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/VEDirectMessage.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/VEDirectMessage.java
@@ -1,5 +1,17 @@
 package io.freedriver.autonomy.jpa.entity;
 
+import java.time.Instant;
+import java.util.Objects;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Index;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
 import io.freedriver.autonomy.jpa.entity.event.Event;
 import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
 import io.freedriver.math.jpa.converter.measurement.CurrentConverter;
@@ -19,18 +31,6 @@ import io.freedriver.victron.TrackerOperation;
 import io.freedriver.victron.VictronProduct;
 import io.freedriver.victron.jpa.FirmwareVersionConverter;
 import io.freedriver.victron.vedirect.OffReason;
-
-import javax.persistence.Convert;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.Index;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
-import javax.persistence.Table;
-import javax.persistence.Transient;
-import java.time.Instant;
-import java.util.Objects;
 
 @Table(
         indexes = {

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/Event.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/Event.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy.jpa.entity.event;
 
-import io.freedriver.autonomy.jpa.entity.EntityBase;
-
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.MappedSuperclass;
-import java.util.Objects;
+
+import io.freedriver.autonomy.jpa.entity.EntityBase;
 
 /**
  * An entity that represents either the initial state of some thing or a change

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/EventCoordinate.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/EventCoordinate.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy.jpa.entity.event;
 
-import io.freedriver.autonomy.jpa.entity.EmbeddedEntityBase;
-
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import java.util.Objects;
+
+import io.freedriver.autonomy.jpa.entity.EmbeddedEntityBase;
 
 /**
  * This class seeks to describe where an event came from, both uniquely and nonuniquely.

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/EventDescription.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/EventDescription.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy.jpa.entity.event;
 
-import io.freedriver.autonomy.jpa.entity.EmbeddedEntityBase;
-
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import java.util.Objects;
+
+import io.freedriver.autonomy.jpa.entity.EmbeddedEntityBase;
 
 @Embeddable
 public class EventDescription extends EmbeddedEntityBase {

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/JoystickEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/JoystickEvent.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.jpa.entity.event.input.joystick;
 
+import java.util.Objects;
+import javax.persistence.*;
+
 import io.freedriver.autonomy.jpa.entity.event.Event;
 import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
 import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
-
-import javax.persistence.*;
-import java.util.Objects;
 
 @Entity
 @Table

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/JoystickEventType.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/JoystickEventType.java
@@ -1,10 +1,10 @@
 package io.freedriver.autonomy.jpa.entity.event.input.joystick;
 
-import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
-import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEventType;
-
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
+import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEventType;
 
 public enum JoystickEventType {
     BUTTON_DOWN(1L, true),

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/jstest/JSTestEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/jstest/JSTestEvent.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest;
 
-import io.freedriver.autonomy.jpa.entity.event.StateType;
-
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import io.freedriver.autonomy.jpa.entity.event.StateType;
 
 /**
  * Container for Joystick Event Data.

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/DoubleValueSensorEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/DoubleValueSensorEvent.java
@@ -1,15 +1,15 @@
 package io.freedriver.autonomy.jpa.entity.event.input.sensors;
 
 
-import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
-
+import java.util.Objects;
+import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.Table;
-import java.util.Objects;
-import java.util.UUID;
+
+import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
 
 @Entity
 @Table

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/SensorEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/SensorEvent.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy.jpa.entity.event.input.sensors;
 
-import io.freedriver.autonomy.jpa.entity.event.Event;
-import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
-
-import javax.persistence.Column;
-import javax.persistence.MappedSuperclass;
 import java.util.Objects;
 import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.MappedSuperclass;
+
+import io.freedriver.autonomy.jpa.entity.event.Event;
+import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
 
 @MappedSuperclass
 public abstract class SensorEvent extends Event {

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sbms/SBMSMessage.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sbms/SBMSMessage.java
@@ -1,5 +1,14 @@
 package io.freedriver.autonomy.jpa.entity.event.sbms;
 
+import java.util.Objects;
+import java.util.stream.Stream;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.Index;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
 import io.freedriver.autonomy.jpa.entity.event.Event;
 import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
 import io.freedriver.electrodacus.sbms.ErrorCode;
@@ -12,15 +21,6 @@ import io.freedriver.math.measurement.types.electrical.Power;
 import io.freedriver.math.measurement.types.thermo.Temperature;
 import io.freedriver.math.number.NumberOperations;
 import io.freedriver.math.number.ScaledNumber;
-
-import javax.persistence.Convert;
-import javax.persistence.Entity;
-import javax.persistence.Index;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
-import javax.persistence.Table;
-import java.util.Objects;
-import java.util.stream.Stream;
 
 @Table(
         indexes = {

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/GPSEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/GPSEvent.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.jpa.entity.event.sensor;
 
-import io.freedriver.autonomy.jpa.entity.event.Event;
-import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
-
-import javax.persistence.*;
 import java.math.BigDecimal;
 import java.time.Instant;
+import javax.persistence.*;
+
+import io.freedriver.autonomy.jpa.entity.event.Event;
+import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
 
 @Table
 @Entity

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/TemperatureEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/TemperatureEvent.java
@@ -1,13 +1,13 @@
 package io.freedriver.autonomy.jpa.entity.event.sensor;
 
-import io.freedriver.autonomy.jpa.entity.event.Event;
-import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
-import io.freedriver.math.measurement.types.thermo.Temperature;
-
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
-import java.util.Objects;
+
+import io.freedriver.autonomy.jpa.entity.event.Event;
+import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
+import io.freedriver.math.measurement.types.thermo.Temperature;
 
 @Table
 @Entity

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/TemperatureValue.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/TemperatureValue.java
@@ -1,9 +1,9 @@
 package io.freedriver.autonomy.jpa.entity.event.sensor;
 
+import static io.freedriver.autonomy.jpa.entity.event.sensor.TemperatureUnit.KELVIN;
+
 import java.math.BigDecimal;
 import java.util.Objects;
-
-import static io.freedriver.autonomy.jpa.entity.event.sensor.TemperatureUnit.KELVIN;
 
 public class TemperatureValue implements Comparable<TemperatureValue> {
     private static final BigDecimal EQUIVALENCE = new BigDecimal("0.000000000001");

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/speech/SpeechEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/speech/SpeechEvent.java
@@ -1,13 +1,13 @@
 package io.freedriver.autonomy.jpa.entity.event.speech;
 
-import io.freedriver.autonomy.jpa.entity.event.Event;
-
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.Table;
-import java.util.Objects;
+
+import io.freedriver.autonomy.jpa.entity.event.Event;
 
 @Entity
 @Table

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/Chemistries.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/Chemistries.java
@@ -1,14 +1,14 @@
 package io.freedriver.autonomy.jpa.entity.math;
 
-import io.freedriver.math.measurement.types.electrical.Potential;
-import io.freedriver.math.number.ScaledNumber;
+import static io.freedriver.math.UnitPrefix.ONE;
 
 import java.math.BigDecimal;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.freedriver.math.UnitPrefix.ONE;
+import io.freedriver.math.measurement.types.electrical.Potential;
+import io.freedriver.math.number.ScaledNumber;
 
 public enum Chemistries {
     CHEM_18650(VoltageSoc.of(new Potential(ScaledNumber.of(3.2, ONE)), 0),

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/SocRange.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/SocRange.java
@@ -1,9 +1,9 @@
 package io.freedriver.autonomy.jpa.entity.math;
 
-import io.freedriver.math.measurement.types.electrical.Potential;
-
 import java.math.BigDecimal;
 import java.util.List;
+
+import io.freedriver.math.measurement.types.electrical.Potential;
 
 public class SocRange {
     private final VoltageSoc bottom;

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/StateOfChargeConfig.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/StateOfChargeConfig.java
@@ -1,14 +1,14 @@
 package io.freedriver.autonomy.jpa.entity.math;
 
-import io.freedriver.math.measurement.types.electrical.Potential;
-import io.freedriver.math.number.ScaledNumber;
+import static io.freedriver.math.UnitPrefix.ONE;
 
 import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static io.freedriver.math.UnitPrefix.ONE;
+import io.freedriver.math.measurement.types.electrical.Potential;
+import io.freedriver.math.number.ScaledNumber;
 
 // 3.2 -> 4.2
 // 19.2 -> 25.2

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/VoltageSoc.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/VoltageSoc.java
@@ -1,9 +1,9 @@
 package io.freedriver.autonomy.jpa.entity.math;
 
+import java.math.BigDecimal;
+
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.types.electrical.Potential;
-
-import java.math.BigDecimal;
 
 public final class VoltageSoc {
     private final Potential voltage;

--- a/jpa/src/test/java/io/freedriver/autonomy/jpa/iface/PositionalTest.java
+++ b/jpa/src/test/java/io/freedriver/autonomy/jpa/iface/PositionalTest.java
@@ -1,6 +1,8 @@
 package io.freedriver.autonomy.jpa.iface;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Objects;
@@ -11,9 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class PositionalTest {
     // Log

--- a/pom.xml
+++ b/pom.xml
@@ -71,4 +71,42 @@
       <url>http://oss.sonatype.org/content/repositories/snapshots</url>
     </repository>
   </repositories>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- Spotless: enforces import order and removes unused imports -->
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.43.0</version>
+          <configuration>
+            <java>
+              <importOrder>
+                <order>java, javax, jakarta, org, com, io</order>
+              </importOrder>
+              <removeUnusedImports />
+            </java>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <!-- Enforce Spotless formatting (including imports) on build -->
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>spotless-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -20,6 +20,7 @@
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>1.12.2.Final</quarkus.platform.version>
+        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/quarkus/src/main/java/io/freedriver/autonomy/Autonomy.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/Autonomy.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy;
 
+import java.sql.SQLException;
+import java.util.function.BiConsumer;
+
 import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
 import org.h2.tools.Server;
-
-import java.sql.SQLException;
-import java.util.function.BiConsumer;
 
 @QuarkusMain
 public class Autonomy {

--- a/quarkus/src/main/java/io/freedriver/autonomy/async/EventInitializationService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/async/EventInitializationService.java
@@ -1,19 +1,5 @@
 package io.freedriver.autonomy.async;
 
-import io.freedriver.autonomy.event.input.joystick.jstest.AllJoysticks;
-import io.freedriver.autonomy.jpa.entity.event.input.joystick.JoystickEvent;
-import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
-import io.freedriver.autonomy.service.SimpleAliasService;
-import io.freedriver.electrodacus.sbms.SBMS0Finder;
-import io.freedriver.electrodacus.sbms.SBMSMessage;
-import io.freedriver.victron.VEDirectMessage;
-import io.freedriver.victron.VEDirectReader;
-import io.quarkus.runtime.StartupEvent;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -26,6 +12,20 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import io.freedriver.autonomy.event.input.joystick.jstest.AllJoysticks;
+import io.freedriver.autonomy.jpa.entity.event.input.joystick.JoystickEvent;
+import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
+import io.freedriver.autonomy.service.SimpleAliasService;
+import io.freedriver.electrodacus.sbms.SBMS0Finder;
+import io.freedriver.electrodacus.sbms.SBMSMessage;
+import io.freedriver.victron.VEDirectMessage;
+import io.freedriver.victron.VEDirectReader;
+import io.quarkus.runtime.StartupEvent;
 
 @ApplicationScoped
 public class EventInitializationService extends BaseService {

--- a/quarkus/src/main/java/io/freedriver/autonomy/async/VEDirectDeviceService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/async/VEDirectDeviceService.java
@@ -1,9 +1,5 @@
 package io.freedriver.autonomy.async;
 
-import io.freedriver.electrodacus.sbms.SBMS0Finder;
-import io.freedriver.victron.VEDirectReader;
-
-import javax.enterprise.context.ApplicationScoped;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
@@ -12,6 +8,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+import javax.enterprise.context.ApplicationScoped;
+
+import io.freedriver.electrodacus.sbms.SBMS0Finder;
+import io.freedriver.victron.VEDirectReader;
 
 @ApplicationScoped
 public class VEDirectDeviceService extends BaseService {

--- a/quarkus/src/main/java/io/freedriver/autonomy/async/VEDirectHistoricalOperations.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/async/VEDirectHistoricalOperations.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.async;
 
-import io.freedriver.victron.VEDirectMessage;
-import io.freedriver.victron.VictronProduct;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
+
+import io.freedriver.victron.VEDirectMessage;
+import io.freedriver.victron.VictronProduct;
 
 public enum VEDirectHistoricalOperations {
     VOLTAGE_CHANGE(VEDirectHistoricalOperations::handleVoltageTrends);

--- a/quarkus/src/main/java/io/freedriver/autonomy/async/XMLVoid.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/async/XMLVoid.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy.async;
 
-import org.w3c.dom.Document;
-
-import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
 
 public class XMLVoid {
     public static final Logger LOGGER = Logger.getLogger(XMLVoid.class.getName());

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/AttributeCache.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/AttributeCache.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.cdi;
 
-import org.infinispan.Cache;
-
+import java.util.function.Function;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.persistence.metamodel.SingularAttribute;
-import java.util.function.Function;
+
+import org.infinispan.Cache;
 
 @ApplicationScoped
 public class AttributeCache {

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/provider/CacheProvider.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/provider/CacheProvider.java
@@ -1,5 +1,14 @@
 package io.freedriver.autonomy.cdi.provider;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
 import io.freedriver.autonomy.Autonomy;
 import io.freedriver.autonomy.cdi.qualifier.AttributeCache;
 import io.freedriver.autonomy.cdi.qualifier.AutonomyCache;
@@ -12,15 +21,6 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 @ApplicationScoped
 public class CacheProvider {

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/provider/ConfigurationProvider.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/provider/ConfigurationProvider.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.cdi.provider;
 
-import io.freedriver.jsonlink.config.ConnectorConfig;
-
+import java.io.IOException;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
-import java.io.IOException;
+
+import io.freedriver.jsonlink.config.ConnectorConfig;
 
 @ApplicationScoped
 public class ConfigurationProvider {

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/provider/LiquibaseProvider.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/provider/LiquibaseProvider.java
@@ -2,48 +2,8 @@ package io.freedriver.autonomy.cdi.provider;
 
 import javax.enterprise.context.Dependent;
 
-//import liquibase.integration.cdi.CDILiquibaseConfig;
-//import liquibase.integration.cdi.annotations.LiquibaseType;
-/*
-import liquibase.resource.ClassLoaderResourceAccessor;
-import liquibase.resource.ResourceAccessor;
-
-import javax.annotation.Resource;
-import javax.enterprise.context.Dependent;
-import javax.enterprise.inject.Produces;
-import javax.sql.DataSource;
-import java.sql.SQLException;
-*/
-// TODO
+// TODO: implement Liquibase integration
 @Dependent
 public class LiquibaseProvider {
-
-
-    //@Resource
-    //private DataSource myDataSource;
-
-    /*
-    @Produces
-    @LiquibaseType
-    public CDILiquibaseConfig createConfig() {
-        CDILiquibaseConfig config = new CDILiquibaseConfig();
-        config.setChangeLog("autonomy/databaseChangeLog.xml");
-        return config;
-    }
-
-    @Produces
-    @LiquibaseType
-    public DataSource createDataSource() throws SQLException {
-        return myDataSource;
-    }
-
-    @Produces
-    @LiquibaseType
-    public ResourceAccessor create() {
-        return new ClassLoaderResourceAccessor(getClass().getClassLoader());
-    }
-
-     */
-
 
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/AttributeCache.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/AttributeCache.java
@@ -1,8 +1,7 @@
 package io.freedriver.autonomy.cdi.qualifier;
 
-import javax.enterprise.util.Nonbinding;
-import javax.inject.Qualifier;
 import java.lang.annotation.*;
+import javax.inject.Qualifier;
 
 @Qualifier
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/AutonomyCache.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/AutonomyCache.java
@@ -1,7 +1,7 @@
 package io.freedriver.autonomy.cdi.qualifier;
 
-import javax.inject.Qualifier;
 import java.lang.annotation.*;
+import javax.inject.Qualifier;
 
 @Qualifier
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/ByUUID.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/ByUUID.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.cdi.qualifier;
 
-import javax.enterprise.util.AnnotationLiteral;
-import javax.enterprise.util.Nonbinding;
-import javax.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.UUID;
+import javax.enterprise.util.AnnotationLiteral;
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
 
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/ConnectorCache.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/ConnectorCache.java
@@ -1,7 +1,7 @@
 package io.freedriver.autonomy.cdi.qualifier;
 
-import javax.inject.Qualifier;
 import java.lang.annotation.*;
+import javax.inject.Qualifier;
 
 @Qualifier
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/H2Database.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/H2Database.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.cdi.qualifier;
 
-import javax.enterprise.util.Nonbinding;
-import javax.inject.Qualifier;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
 
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/OneSecondCache.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/OneSecondCache.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.cdi.qualifier;
 
-import javax.inject.Qualifier;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import javax.inject.Qualifier;
 
 @Qualifier
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/SensorCache.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/SensorCache.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.cdi.qualifier;
 
-import javax.inject.Qualifier;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import javax.inject.Qualifier;
 
 @Qualifier
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/SpeechCache.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/SpeechCache.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.cdi.qualifier;
 
-import javax.inject.Qualifier;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import javax.inject.Qualifier;
 
 @Qualifier
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/VEProduct.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/qualifier/VEProduct.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy.cdi.qualifier;
 
 
-import io.freedriver.victron.VictronProduct;
-
-import javax.enterprise.util.Nonbinding;
-import javax.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
+
+import io.freedriver.victron.VictronProduct;
 
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/ObjectMapperContextResolver.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/ObjectMapperContextResolver.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.jaxrs;
 
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.freedriver.autonomy.vedirect.jackson.VEDirectModule;
 import io.freedriver.jsonlink.jackson.JsonLinkModule;
-
-import javax.ws.rs.ext.ContextResolver;
-import javax.ws.rs.ext.Provider;
 
 @Provider
 public class ObjectMapperContextResolver implements ContextResolver<ObjectMapper> {

--- a/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/config/ConfigurationEndpoint.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/config/ConfigurationEndpoint.java
@@ -1,13 +1,13 @@
 package io.freedriver.autonomy.jaxrs.endpoint.config;
 
-import io.freedriver.jsonlink.config.ConnectorConfig;
-
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+
+import io.freedriver.jsonlink.config.ConnectorConfig;
 
 @Path("config")
 @Produces(MediaType.APPLICATION_JSON)

--- a/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/event/JoystickEventEndpoint.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/event/JoystickEventEndpoint.java
@@ -1,14 +1,13 @@
 package io.freedriver.autonomy.jaxrs.endpoint.event;
 
-import io.freedriver.autonomy.jaxrs.endpoint.EventApi;
-import io.freedriver.autonomy.jpa.entity.event.input.joystick.JoystickEvent;
-import io.freedriver.autonomy.service.JoystickEventCrudService;
-
+import java.util.stream.Stream;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
-import javax.xml.datatype.Duration;
-import java.util.stream.Stream;
+
+import io.freedriver.autonomy.jaxrs.endpoint.EventApi;
+import io.freedriver.autonomy.jpa.entity.event.input.joystick.JoystickEvent;
+import io.freedriver.autonomy.service.JoystickEventCrudService;
 
 @RequestScoped
 public class JoystickEventEndpoint implements EventApi<JoystickEvent> {

--- a/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/jsonlink/SimpleAliasHandler.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/jsonlink/SimpleAliasHandler.java
@@ -1,23 +1,23 @@
 package io.freedriver.autonomy.jaxrs.endpoint.jsonlink;
 
-import io.freedriver.autonomy.jaxrs.endpoint.SimpleAliasApi;
-import io.freedriver.autonomy.jaxrs.view.AliasView;
-import io.freedriver.autonomy.service.ConnectorService;
-import io.freedriver.autonomy.service.SimpleAliasService;
-import io.freedriver.jsonlink.config.v2.Appliance;
-
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.freedriver.autonomy.jaxrs.endpoint.SimpleAliasApi;
+import io.freedriver.autonomy.jaxrs.view.AliasView;
+import io.freedriver.autonomy.service.ConnectorService;
+import io.freedriver.autonomy.service.SimpleAliasService;
+import io.freedriver.jsonlink.config.v2.Appliance;
 
 @RequestScoped
 @Path(SimpleAliasApi.ROOT)

--- a/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/sbms/SBMSEndpoint.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/sbms/SBMSEndpoint.java
@@ -1,15 +1,15 @@
 package io.freedriver.autonomy.jaxrs.endpoint.sbms;
 
-import io.freedriver.autonomy.entity.view.LithiumBatteryView;
-import io.freedriver.autonomy.jaxrs.endpoint.SBMSApi;
-import io.freedriver.autonomy.service.SBMSEventService;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import io.freedriver.autonomy.entity.view.LithiumBatteryView;
+import io.freedriver.autonomy.jaxrs.endpoint.SBMSApi;
+import io.freedriver.autonomy.service.SBMSEventService;
 
 @Path(SBMSApi.ROOT)
 @Produces(APPLICATION_JSON)

--- a/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/vedirect/VEDirectEndpoint.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/vedirect/VEDirectEndpoint.java
@@ -1,18 +1,7 @@
 package io.freedriver.autonomy.jaxrs.endpoint.vedirect;
 
-import io.freedriver.autonomy.entity.view.ControllerView;
-import io.freedriver.autonomy.exception.VEDirectApiException;
-import io.freedriver.autonomy.jaxrs.endpoint.VEDirectApi;
-import io.freedriver.autonomy.jpa.entity.VEDirectMessage;
-import io.freedriver.autonomy.vedirect.VEDirectMessageService;
-import io.freedriver.victron.VEDirectColumn;
-import io.freedriver.victron.VictronDevice;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -21,8 +10,19 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import io.freedriver.autonomy.entity.view.ControllerView;
+import io.freedriver.autonomy.exception.VEDirectApiException;
+import io.freedriver.autonomy.jaxrs.endpoint.VEDirectApi;
+import io.freedriver.autonomy.jpa.entity.VEDirectMessage;
+import io.freedriver.autonomy.vedirect.VEDirectMessageService;
+import io.freedriver.victron.VEDirectColumn;
+import io.freedriver.victron.VictronDevice;
 
 @RequestScoped
 @Path(VEDirectApi.ROOT)

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/BoardAnalogHistory.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/BoardAnalogHistory.java
@@ -1,9 +1,9 @@
 package io.freedriver.autonomy.service;
 
-import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
 
 public class BoardAnalogHistory {
     private Map<Identifier, Integer> minimums = new LinkedHashMap<>();

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorService.java
@@ -1,35 +1,24 @@
 package io.freedriver.autonomy.service;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import javax.enterprise.context.ApplicationScoped;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import io.freedriver.jsonlink.Connector;
-import io.freedriver.jsonlink.Connectors;
 import io.freedriver.jsonlink.jackson.JsonLinkModule;
 import io.freedriver.jsonlink.jackson.schema.v1.AnalogRead;
 import io.freedriver.jsonlink.jackson.schema.v1.DigitalWrite;
 import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
 import io.freedriver.jsonlink.jackson.schema.v1.Request;
 import io.freedriver.jsonlink.jackson.schema.v1.Response;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.WebApplicationException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * The service by which we interact with connectors.

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorServiceCommon.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorServiceCommon.java
@@ -1,25 +1,9 @@
 package io.freedriver.autonomy.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import io.freedriver.jsonlink.Connector;
-import io.freedriver.jsonlink.Connectors;
-import io.freedriver.jsonlink.jackson.JsonLinkModule;
-import io.freedriver.jsonlink.jackson.schema.v1.AnalogRead;
-import io.freedriver.jsonlink.jackson.schema.v1.DigitalWrite;
-import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-import io.freedriver.jsonlink.jackson.schema.v1.Request;
-import io.freedriver.jsonlink.jackson.schema.v1.Response;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.WebApplicationException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -29,7 +13,16 @@ import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.WebApplicationException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.freedriver.jsonlink.Connector;
+import io.freedriver.jsonlink.Connectors;
+import io.freedriver.jsonlink.jackson.JsonLinkModule;
+import io.freedriver.jsonlink.jackson.schema.v1.Request;
+import io.freedriver.jsonlink.jackson.schema.v1.Response;
 
 /**
  * The service by which we interact with connectors.

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/FloatValueSensorEventService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/FloatValueSensorEventService.java
@@ -1,10 +1,10 @@
 package io.freedriver.autonomy.service;
 
-import io.freedriver.autonomy.jpa.entity.event.input.sensors.DoubleValueSensorEvent;
-import io.freedriver.autonomy.service.crud.EventCrudService;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.transaction.Transactional;
+
+import io.freedriver.autonomy.jpa.entity.event.input.sensors.DoubleValueSensorEvent;
+import io.freedriver.autonomy.service.crud.EventCrudService;
 
 @ApplicationScoped
 public class FloatValueSensorEventService extends EventCrudService<DoubleValueSensorEvent> {

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/JoystickEventCrudService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/JoystickEventCrudService.java
@@ -1,15 +1,15 @@
 package io.freedriver.autonomy.service;
 
-import io.freedriver.autonomy.jpa.entity.event.input.joystick.JoystickEvent;
-import io.freedriver.autonomy.service.crud.EventCrudService;
-
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
 import javax.transaction.Transactional;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
+import io.freedriver.autonomy.jpa.entity.event.input.joystick.JoystickEvent;
+import io.freedriver.autonomy.service.crud.EventCrudService;
 
 @ApplicationScoped
 public class JoystickEventCrudService extends EventCrudService<JoystickEvent> {

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/PinCoordinate.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/PinCoordinate.java
@@ -1,9 +1,9 @@
 package io.freedriver.autonomy.service;
 
-import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-
 import java.util.Objects;
 import java.util.UUID;
+
+import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
 
 public class PinCoordinate {
     private final UUID boardId;

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/ReportingService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/ReportingService.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy.service;
 
-import javax.enterprise.context.ApplicationScoped;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class ReportingService {

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/RestartOnHashChangeService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/RestartOnHashChangeService.java
@@ -1,11 +1,5 @@
 package io.freedriver.autonomy.service;
 
-import io.freedriver.base.util.crypt.CryptUtils;
-import io.freedriver.base.util.crypt.HashAlgorithms;
-import io.quarkus.runtime.StartupEvent;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,6 +14,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import io.freedriver.base.util.crypt.CryptUtils;
+import io.freedriver.base.util.crypt.HashAlgorithms;
+import io.quarkus.runtime.StartupEvent;
 
 @ApplicationScoped
 public class RestartOnHashChangeService {

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/SBMSEventService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/SBMSEventService.java
@@ -1,22 +1,5 @@
 package io.freedriver.autonomy.service;
 
-import io.freedriver.autonomy.cdi.qualifier.OneSecondCache;
-import io.freedriver.autonomy.entity.view.LithiumBatteryView;
-import io.freedriver.autonomy.jpa.entity.EntityBase_;
-import io.freedriver.autonomy.jpa.entity.event.Event;
-import io.freedriver.autonomy.jpa.entity.event.Event_;
-import io.freedriver.autonomy.jpa.entity.event.sbms.SBMSMessage;
-import io.freedriver.autonomy.service.crud.EventCrudService;
-import org.infinispan.Cache;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Default;
-import javax.inject.Inject;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
-import javax.transaction.Transactional;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -25,6 +8,23 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Default;
+import javax.inject.Inject;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import javax.transaction.Transactional;
+
+import io.freedriver.autonomy.cdi.qualifier.OneSecondCache;
+import io.freedriver.autonomy.entity.view.LithiumBatteryView;
+import io.freedriver.autonomy.jpa.entity.EntityBase_;
+import io.freedriver.autonomy.jpa.entity.event.Event;
+import io.freedriver.autonomy.jpa.entity.event.Event_;
+import io.freedriver.autonomy.jpa.entity.event.sbms.SBMSMessage;
+import io.freedriver.autonomy.service.crud.EventCrudService;
+import org.infinispan.Cache;
 
 @ApplicationScoped
 public class SBMSEventService extends EventCrudService<SBMSMessage> {

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
@@ -1,5 +1,33 @@
 package io.freedriver.autonomy.service;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Default;
+import javax.inject.Inject;
+
 import io.freedriver.autonomy.Autonomy;
 import io.freedriver.autonomy.cdi.qualifier.ConnectorCache;
 import io.freedriver.autonomy.cdi.qualifier.SensorCache;
@@ -25,34 +53,6 @@ import io.freedriver.jsonlink.jackson.schema.v1.ModeSet;
 import io.freedriver.jsonlink.jackson.schema.v1.Request;
 import io.freedriver.jsonlink.jackson.schema.v1.Response;
 import org.infinispan.Cache;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Default;
-import javax.inject.Inject;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @ApplicationScoped
 public class SimpleAliasService  {

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/SpeechService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/SpeechService.java
@@ -1,16 +1,5 @@
 package io.freedriver.autonomy.service;
 
-import io.freedriver.autonomy.cdi.qualifier.SpeechCache;
-import io.freedriver.autonomy.jpa.entity.event.speech.SpeechEvent;
-import io.freedriver.autonomy.jpa.entity.event.speech.SpeechEventType;
-import io.freedriver.autonomy.service.crud.JPACrudService;
-import io.freedriver.base.util.Festival;
-import org.infinispan.Cache;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-import javax.transaction.Transactional;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -20,6 +9,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.transaction.Transactional;
+
+import io.freedriver.autonomy.jpa.entity.event.speech.SpeechEvent;
+import io.freedriver.autonomy.jpa.entity.event.speech.SpeechEventType;
+import io.freedriver.autonomy.service.crud.JPACrudService;
 
 @ApplicationScoped
 public class SpeechService extends JPACrudService<SpeechEvent> {

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/crud/CRUDInterface.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/crud/CRUDInterface.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.service.crud;
 
 
-import io.freedriver.autonomy.jpa.iface.Positional;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+
+import io.freedriver.autonomy.jpa.iface.Positional;
 
 public interface CRUDInterface<I, T extends Positional> {
     // CREATE

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/crud/EventCrudService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/crud/EventCrudService.java
@@ -1,23 +1,19 @@
 package io.freedriver.autonomy.service.crud;
 
-import io.freedriver.autonomy.jpa.entity.VEDirectMessage;
-import io.freedriver.autonomy.jpa.entity.VEDirectMessage_;
-import io.freedriver.autonomy.jpa.entity.event.Event;
-import io.freedriver.autonomy.jpa.entity.event.Event_;
-import io.freedriver.victron.VictronDevice;
-
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaDelete;
-import javax.persistence.criteria.Root;
-import javax.transaction.Transactional;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaDelete;
+import javax.persistence.criteria.Root;
+import javax.transaction.Transactional;
+
+import io.freedriver.autonomy.jpa.entity.event.Event;
+import io.freedriver.autonomy.jpa.entity.event.Event_;
 
 
 public abstract class EventCrudService<E extends Event> extends JPACrudService<E> {

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/crud/JPACrudService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/crud/JPACrudService.java
@@ -1,9 +1,9 @@
 package io.freedriver.autonomy.service.crud;
 
-import io.freedriver.autonomy.jpa.entity.EntityBase;
-import io.freedriver.autonomy.jpa.entity.event.Event_;
-import io.freedriver.autonomy.util.Benchmark;
-
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -12,11 +12,10 @@ import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
-import javax.ws.rs.core.MediaType;
-import java.util.Optional;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import io.freedriver.autonomy.jpa.entity.EntityBase;
+import io.freedriver.autonomy.jpa.entity.event.Event_;
+import io.freedriver.autonomy.util.Benchmark;
 
 public abstract class JPACrudService<E extends EntityBase> {
     @Inject

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/crud/TTLEnforcementService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/crud/TTLEnforcementService.java
@@ -1,5 +1,17 @@
 package io.freedriver.autonomy.service.crud;
 
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
 import io.freedriver.autonomy.Autonomy;
 import io.freedriver.autonomy.jaxrs.ObjectMapperContextResolver;
 import io.freedriver.base.util.file.DirectoryProviders;
@@ -7,18 +19,6 @@ import io.freedriver.base.util.tedious.Loops;
 import io.freedriver.jsonlink.config.v2.Mappings;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Any;
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * This service enforces TTLs on all Event data.

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/CacheStat.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/CacheStat.java
@@ -1,9 +1,9 @@
 package io.freedriver.autonomy.vedirect;
 
-import io.freedriver.autonomy.jpa.entity.VEDirectMessage;
-
-import javax.persistence.metamodel.SingularAttribute;
 import java.util.function.Function;
+import javax.persistence.metamodel.SingularAttribute;
+
+import io.freedriver.autonomy.jpa.entity.VEDirectMessage;
 
 public interface CacheStat<T> {
     SingularAttribute<VEDirectMessage, T> getAttribute();

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/CacheStats.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/CacheStats.java
@@ -1,10 +1,10 @@
 package io.freedriver.autonomy.vedirect;
 
+import java.util.function.Function;
+import javax.persistence.metamodel.SingularAttribute;
+
 import io.freedriver.autonomy.jpa.entity.VEDirectMessage;
 import io.freedriver.autonomy.jpa.entity.VEDirectMessage_;
-
-import javax.persistence.metamodel.SingularAttribute;
-import java.util.function.Function;
 
 public enum CacheStats implements CacheStat {
     PANEL_VOLTAGE(VEDirectMessage_.panelVoltage, VEDirectMessage::getPanelVoltage),

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageActor.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageActor.java
@@ -1,17 +1,5 @@
 package io.freedriver.autonomy.vedirect;
 
-import io.freedriver.autonomy.cdi.qualifier.VEProduct;
-import io.freedriver.autonomy.service.ReportingService;
-import io.freedriver.victron.VEDirectMessage;
-import io.freedriver.victron.VictronDevice;
-import io.freedriver.victron.VictronProduct;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Default;
-import javax.enterprise.inject.Produces;
-import javax.enterprise.inject.spi.InjectionPoint;
-import javax.inject.Inject;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,6 +8,18 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import io.freedriver.autonomy.cdi.qualifier.VEProduct;
+import io.freedriver.autonomy.service.ReportingService;
+import io.freedriver.victron.VEDirectMessage;
+import io.freedriver.victron.VictronDevice;
+import io.freedriver.victron.VictronProduct;
 
 @ApplicationScoped
 public class VEDirectMessageActor {

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageChange.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageChange.java
@@ -1,8 +1,5 @@
 package io.freedriver.autonomy.vedirect;
 
-import io.freedriver.math.measurement.types.electrical.Potential;
-import io.freedriver.victron.VEDirectMessage;
-
 import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -11,6 +8,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import io.freedriver.math.measurement.types.electrical.Potential;
+import io.freedriver.victron.VEDirectMessage;
 
 public enum VEDirectMessageChange {
     RELAY_STATE("Relay state", VEDirectMessage::getRelayState),

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageLogging.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageLogging.java
@@ -1,9 +1,9 @@
 package io.freedriver.autonomy.vedirect;
 
-import io.freedriver.victron.VEDirectMessage;
-
 import java.time.Duration;
 import java.util.stream.Stream;
+
+import io.freedriver.victron.VEDirectMessage;
 
 public enum VEDirectMessageLogging {
     PV_POWER {

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageService.java
@@ -1,5 +1,22 @@
 package io.freedriver.autonomy.vedirect;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.Tuple;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
+import javax.transaction.Transactional;
+
 import io.freedriver.autonomy.cache.CacheKey;
 import io.freedriver.autonomy.cdi.AttributeCache;
 import io.freedriver.autonomy.cdi.qualifier.AutonomyCache;
@@ -17,25 +34,6 @@ import io.freedriver.math.measurement.types.electrical.Potential;
 import io.freedriver.math.measurement.types.electrical.Power;
 import io.freedriver.victron.VictronDevice;
 import org.infinispan.Cache;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.Initialized;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-import javax.persistence.Tuple;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Subquery;
-import javax.transaction.Transactional;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.util.Optional;
-import java.util.Set;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @ApplicationScoped // TODO EventService
 public class VEDirectMessageService extends EventCrudService<VEDirectMessage> {

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/jackson/MeasurementDeserializer.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/jackson/MeasurementDeserializer.java
@@ -1,14 +1,14 @@
 package io.freedriver.autonomy.vedirect.jackson;
 
+import java.io.IOException;
+import java.util.function.Function;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.freedriver.math.measurement.types.Measurement;
 import io.freedriver.math.number.ScaledNumber;
-
-import java.io.IOException;
-import java.util.function.Function;
 
 public class MeasurementDeserializer<M extends Measurement<M>> extends JsonDeserializer<M> {
     private final Function<ScaledNumber, M> constructor;

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/jackson/MeasurementSerializer.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/jackson/MeasurementSerializer.java
@@ -1,11 +1,11 @@
 package io.freedriver.autonomy.vedirect.jackson;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.freedriver.math.measurement.types.Measurement;
-
-import java.io.IOException;
 
 public class MeasurementSerializer<M extends Measurement<M>> extends JsonSerializer<M> {
     @Override

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/jackson/VEDirectModule.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/jackson/VEDirectModule.java
@@ -1,12 +1,12 @@
 package io.freedriver.autonomy.vedirect.jackson;
 
 
+import java.util.function.Function;
+
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.freedriver.math.measurement.types.Measurement;
 import io.freedriver.math.measurement.types.electrical.*;
 import io.freedriver.math.number.ScaledNumber;
-
-import java.util.function.Function;
 
 public class VEDirectModule extends SimpleModule {
     public VEDirectModule() {

--- a/quarkus/src/main/java/io/freedriver/autonomy/websocket/AliasWebsocket.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/websocket/AliasWebsocket.java
@@ -1,5 +1,7 @@
 package io.freedriver.autonomy.websocket;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.enterprise.context.ApplicationScoped;
 import javax.websocket.OnClose;
 import javax.websocket.OnError;
@@ -8,8 +10,6 @@ import javax.websocket.OnOpen;
 import javax.websocket.Session;
 import javax.websocket.server.PathParam;
 import javax.websocket.server.ServerEndpoint;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
 @ServerEndpoint("/alias")

--- a/quarkus/src/test/java/io/freedriver/autonomy/GreetingResourceTest.java
+++ b/quarkus/src/test/java/io/freedriver/autonomy/GreetingResourceTest.java
@@ -1,10 +1,8 @@
 package io.freedriver.autonomy;
 
+
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
-
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
 public class GreetingResourceTest {


### PR DESCRIPTION
This is a spotless-only PR: adds the Spotless Maven plugin (matching the one in freedriver) and runs `mvn spotless:apply` to fix imports.

## Changes
- Added `spotless-maven-plugin` 2.43.0 to the root `pom.xml` (in `pluginManagement` and with `verify` phase check execution), using the same import order config: `java, javax, jakarta, org, com, io` + `removeUnusedImports`.
- Ran Spotless apply, which cleaned up 88 files (primarily reordering imports and removing unused ones across api, jpa, quarkus, and other modules).
- As a side fix to allow the build/apply to succeed, added the missing `<surefire-plugin.version>3.0.0-M5</surefire-plugin.version>` to `quarkus/pom.xml`.

This gets the 'noisy' formatting changes out of the way in one dedicated PR, so future work (including the planned Quarkus 3.37 upgrade) can stay clean.

All changes committed and pushed as **Yuni**.

PR created using yuni's PAT (`GH_TOKEN`).

See also freedriver PRs for the parallel setup.