### PR TITLE
Serial hotplug via inotify CDI events

### DIFF
--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -112,6 +112,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.freedriver</groupId>
+            <artifactId>inotify-cdi</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.freedriver.autonomy</groupId>
             <artifactId>autonomy-api</artifactId>
         </dependency>

--- a/quarkus/src/main/java/io/freedriver/autonomy/events/SerialHotplugService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/events/SerialHotplugService.java
@@ -1,0 +1,24 @@
+package io.freedriver.autonomy.events;
+
+import io.freedriver.inotify.cdi.InotifyFilesystemEvent;
+import io.freedriver.serial.api.connection.SerialConnectionManager;
+import io.freedriver.serial.connection.DefaultSerialConnectionManager;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+@ApplicationScoped
+@Slf4j
+public class SerialHotplugService {
+
+    @Inject
+    SerialConnectionManager connectionManager;
+
+    void onFilesystemEvent(@Observes InotifyFilesystemEvent event) {
+        log.debug("Serial hotplug signal: {}", event);
+        if (connectionManager instanceof DefaultSerialConnectionManager manager) {
+            manager.refreshConnections();
+        }
+    }
+}

--- a/quarkus/src/main/java/io/freedriver/autonomy/events/SerialHotplugService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/events/SerialHotplugService.java
@@ -8,6 +8,13 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Reacts to serial device hotplug signals from freedriver {@code inotify-cdi}.
+ *
+ * <p>{@link io.freedriver.inotify.cdi.InotifyCdiBridge} publishes {@link InotifyFilesystemEvent}
+ * when {@link io.freedriver.inotify.cdi.InotifyLifecycle} receives kernel inotify notifications
+ * for {@code /dev/serial/by-id}.
+ */
 @ApplicationScoped
 @Slf4j
 public class SerialHotplugService {

--- a/quarkus/src/main/java/io/freedriver/autonomy/events/VEDirectEventSource.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/events/VEDirectEventSource.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import io.freedriver.inotify.cdi.InotifyFilesystemEvent;
 import io.freedriver.serial.api.connection.SerialConnectionHandle;
 import io.freedriver.serial.api.connection.SerialConnectionManager;
 import io.freedriver.serial.api.connection.SerialDeviceIdentity;
@@ -17,6 +18,7 @@ import io.freedriver.victron.VEDirectMessage;
 import io.freedriver.victron.VEDirectMessageStream;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
@@ -67,6 +69,12 @@ public class VEDirectEventSource implements EventSource {
             }
         }
         readers.clear();
+    }
+
+    void onSerialHotplug(@Observes InotifyFilesystemEvent event) {
+        if (running) {
+            discoverNow();
+        }
     }
 
     private void discoverNow() {


### PR DESCRIPTION
## Summary

- Adds `inotify-cdi` dependency
- `SerialHotplugService` observes `InotifyFilesystemEvent` → `refreshConnections()`
- `VEDirectEventSource` rediscovers immediately on hotplug (not just 2s poll)

## Stack

- Depends on #8 (EventSource SPI)
- Requires **freedriver #11** (inotify modules)

## Test plan

- [ ] Plug/unplug USB serial device on Linux; confirm reconnect without app restart