### PR TITLE
Java 23, Lombok @Slf4j, records, and GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Maven verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build, test, and Spotless check
+        run: mvn --batch-mode --no-transfer-progress verify

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,6 +46,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerHistoryView.java
+++ b/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerHistoryView.java
@@ -1,31 +1,7 @@
 package io.freedriver.autonomy.entity.view;
 
-public class ControllerHistoryView {
-    private final double maxPanelPower;
-    private final double maxPanelVoltage;
-    private final double maxMainVoltage;
-    private final double recordYield;
-
-    public ControllerHistoryView(double maxPanelPower, double maxPanelVoltage, double maxMainVoltage, double recordYield) {
-        this.maxPanelPower = maxPanelPower;
-        this.maxPanelVoltage = maxPanelVoltage;
-        this.maxMainVoltage = maxMainVoltage;
-        this.recordYield = recordYield;
-    }
-
-    public double getMaxPanelPower() {
-        return maxPanelPower;
-    }
-
-    public double getMaxPanelVoltage() {
-        return maxPanelVoltage;
-    }
-
-    public double getMaxMainVoltage() {
-        return maxMainVoltage;
-    }
-
-    public double getRecordYield() {
-        return recordYield;
-    }
-}
+public record ControllerHistoryView(
+        double maxPanelPower,
+        double maxPanelVoltage,
+        double maxMainVoltage,
+        double recordYield) {}

--- a/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerStateView.java
+++ b/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerStateView.java
@@ -2,12 +2,7 @@ package io.freedriver.autonomy.entity.view;
 
 import io.freedriver.autonomy.jpa.entity.VEDirectMessage;
 
-public class ControllerStateView {
-    private final VEDirectMessage lastMessage;
-
-    public ControllerStateView(VEDirectMessage lastMessage) {
-        this.lastMessage = lastMessage;
-    }
+public record ControllerStateView(VEDirectMessage lastMessage) {
 
     public Double getYield() {
         return lastMessage.getYieldToday().doubleValue();

--- a/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/AllJoysticks.java
+++ b/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/AllJoysticks.java
@@ -10,18 +10,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
 import io.freedriver.autonomy.util.Delayable;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Single point to discover and monitor all joystick devices on a system.
  */
+@Slf4j
 public class AllJoysticks implements AutoCloseable {
-    private static final Logger LOGGER = Logger.getLogger(AllJoysticks.class.getName());
 
     private final Map<Path, Future<?>> activeJoysticks = new ConcurrentHashMap<>();
     private final Map<Path, FailedJoystick> failedJoystickMap = new ConcurrentHashMap<>();
@@ -76,7 +75,7 @@ public class AllJoysticks implements AutoCloseable {
         Set<FailedJoystick> toRemove = new HashSet<>(failedJoystickMap.values());
         toRemove.stream()
                 .filter(FailedJoystick::failureExpired)
-                .map(FailedJoystick::getPath)
+                .map(FailedJoystick::path)
                 .forEach(failedJoystickMap::remove);
         return failedJoystickMap;
     }
@@ -85,7 +84,7 @@ public class AllJoysticks implements AutoCloseable {
      * Continuously poll for new joysticks, and add them to the pool.
      */
     public void poll() {
-        LOGGER.info("Watching for Joysticks.");
+        log.info("Watching for Joysticks.");
         while (open) {
             populate();
             Delayable.wait(Duration.ofMillis(100));
@@ -107,10 +106,10 @@ public class AllJoysticks implements AutoCloseable {
     private boolean shouldCreateReader(Path path) {
         if (!getActiveJoysticks().containsKey(path)) {
             if (!getFailedJoystickMap().containsKey(path)) {
-                LOGGER.info("New joystick: " + path);
+                log.info("New joystick: {}", path);
                 return true;
             } else {
-                LOGGER.info("Failed joystick: "  + path);
+                log.info("Failed joystick: {}", path);
             }
         }
         return false;
@@ -120,7 +119,7 @@ public class AllJoysticks implements AutoCloseable {
      * Creates a thread for submitting joystick events to the pool.
      */
     private synchronized void constructFromPool(Path path) {
-        LOGGER.info("Joystick " + path.toString() + " joining pool");
+        log.info("Joystick {} joining pool", path);
         try {
             activeJoysticks.put(
                     path,
@@ -129,13 +128,15 @@ public class AllJoysticks implements AutoCloseable {
                                 .apply(JSTestReader
                                         .ofJoystick(path)
                                         .takeWhile(l -> open)).forEach(sink);
-                        LOGGER.info("Closed Stream for Joystick at " + path);
+                        log.info("Closed Stream for Joystick at {}", path);
                     }));
         } catch (Exception e) {
             FailedJoystick failedJoystick = new FailedJoystick(path);
-            LOGGER.log(Level.SEVERE, e, () -> "Failed to assemble Joystick at "
-                    + path.toString() + " into the pool. "
-                    + "Will retry in " + failedJoystick.getDelay().toMillis() + "ms");
+            log.error(
+                    "Failed to assemble Joystick at {} into the pool. Will retry in {}ms",
+                    path,
+                    failedJoystick.getDelay().toMillis(),
+                    e);
             getFailedJoystickMap()
                     .put(path, failedJoystick);
         }

--- a/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/FailedJoystick.java
+++ b/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/FailedJoystick.java
@@ -10,27 +10,11 @@ import java.util.Objects;
 /**
  * Convenience class to keep track of joystick devices that failed to spawn readers.
  */
-public class FailedJoystick {
+public record FailedJoystick(Path path, Instant instant) {
     private static final Duration DEFAULT_DURATION = Duration.of(5, MINUTES);
-
-    private final Path path;
-    private final Instant instant;
-
-    public FailedJoystick(Path path, Instant instant) {
-        this.path = path;
-        this.instant = instant;
-    }
 
     public FailedJoystick(Path path) {
         this(path, Instant.now().plus(DEFAULT_DURATION));
-    }
-
-    public Path getPath() {
-        return path;
-    }
-
-    public Instant getInstant() {
-        return instant;
     }
 
     public boolean failureExpired() {
@@ -51,7 +35,7 @@ public class FailedJoystick {
     }
 
     public Duration getDelay() {
-        return Duration.between(Instant.now(), getInstant())
+        return Duration.between(Instant.now(), instant)
                 .abs();
     }
 }

--- a/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/JSTestReader.java
+++ b/api/src/main/java/io/freedriver/autonomy/event/input/joystick/jstest/JSTestReader.java
@@ -5,8 +5,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -15,9 +13,10 @@ import java.util.stream.Stream;
 import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSMetadata;
 import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
 import io.freedriver.base.util.ProcessUtil;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class JSTestReader {
-    private static final Logger LOGGER = Logger.getLogger(JSTestReader.class.getName());
 
     private static final String HW_TYPE = "hwtype";
     private static final String TITLE = "title";
@@ -55,7 +54,7 @@ public class JSTestReader {
     }
 
     public static void destroyProcess(Process p, Path joystickPath) {
-        LOGGER.info("Destroying Joystick " + joystickPath.toAbsolutePath().toString());
+        log.info("Destroying Joystick {}", joystickPath.toAbsolutePath());
         p.destroyForcibly();
     }
 
@@ -124,8 +123,8 @@ public class JSTestReader {
             } else if (driverMatcher.matches()) {
                 jsMetadata.setDriverVersion(driverMatcher.group(DRIVERVER));
             } else {
-                LOGGER.finest("Not details:");
-                LOGGER.log(Level.FINEST, event);
+                log.trace("Not details:");
+                log.trace("{}", event);
             }
 
             return true;

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -65,6 +65,18 @@
         <artifactId>jakarta.ws.rs-api</artifactId>
         <version>3.1.0</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.16</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -51,6 +51,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/Chemistries.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/Chemistries.java
@@ -23,7 +23,7 @@ public enum Chemistries {
 
     Chemistries(VoltageSoc... VoltageSocs) {
         this(Stream.of(VoltageSocs)
-                .collect(Collectors.toMap(VoltageSoc::getVoltageBase, VoltageSoc::getState, (a, b) -> b)));
+                .collect(Collectors.toMap(VoltageSoc::getVoltageBase, VoltageSoc::state, (a, b) -> b)));
     }
 
     public Map<BigDecimal, BigDecimal> getVoltageMap() {

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/SocRange.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/SocRange.java
@@ -15,7 +15,7 @@ public class SocRange {
     }
 
     public static SocRange of(VoltageSoc bottom, VoltageSoc top) {
-        if (bottom.getVoltage().lessThan(top.getVoltage())) {
+        if (bottom.voltage().lessThan(top.voltage())) {
             return new SocRange(bottom, top);
         }
         return new SocRange(top, bottom);
@@ -26,9 +26,9 @@ public class SocRange {
     }
 
     public BigDecimal calculate(Potential voltage) {
-        Potential range = top.getVoltage().subtract(bottom.getVoltage().getValue());
-        BigDecimal scale = voltage.subtract(bottom.getVoltage()).divide(range).getValue().getValue();
-        BigDecimal socRange = top.getState().subtract(bottom.getState());
+        Potential range = top.voltage().subtract(bottom.voltage().getValue());
+        BigDecimal scale = voltage.subtract(bottom.voltage()).divide(range).getValue().getValue();
+        BigDecimal socRange = top.state().subtract(bottom.state());
         BigDecimal result = scale.multiply(socRange);
         return result;
     }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/StateOfChargeConfig.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/StateOfChargeConfig.java
@@ -41,7 +41,7 @@ public class StateOfChargeConfig {
                 .stream()
                 .map(e -> VoltageSoc.of(new Potential(ScaledNumber.of(e.getKey(), ONE)), e.getValue()))
                 .map(voltageSoc -> voltageSoc.series(cells))
-                .sorted(Comparator.comparing(v -> v.getVoltage().subtract(voltage.getValue()).abs()))
+                .sorted(Comparator.comparing(v -> v.voltage().subtract(voltage.getValue()).abs()))
                 .limit(2)
                 .collect(Collectors.toList()))
                 .calculate(voltage);

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/VoltageSoc.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/VoltageSoc.java
@@ -5,14 +5,7 @@ import java.math.BigDecimal;
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.types.electrical.Potential;
 
-public final class VoltageSoc {
-    private final Potential voltage;
-    private final BigDecimal state;
-
-    private VoltageSoc(Potential voltage, BigDecimal state) {
-        this.voltage = voltage;
-        this.state = state;
-    }
+public record VoltageSoc(Potential voltage, BigDecimal state) {
 
     public static VoltageSoc of(Potential voltage, BigDecimal state) {
         return new VoltageSoc(voltage, state);
@@ -22,16 +15,8 @@ public final class VoltageSoc {
         return new VoltageSoc(voltage, BigDecimal.valueOf(state.doubleValue()));
     }
 
-    public Potential getVoltage() {
-        return voltage;
-    }
-
-    public BigDecimal getState() {
-        return state;
-    }
-
     public BigDecimal getVoltageBase() {
-        return getVoltage().scaleTo(UnitPrefix.ONE)
+        return voltage().scaleTo(UnitPrefix.ONE)
                 .getValue()
                 .getValue();
     }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/util/Base64Serialization.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/util/Base64Serialization.java
@@ -3,11 +3,11 @@ package io.freedriver.autonomy.jpa.util;
 import java.io.*;
 import java.util.Base64;
 import java.util.Optional;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class Base64Serialization {
-    private static final Logger LOGGER = Logger.getLogger(Base64Serialization.class.getName());
 
     private Base64Serialization() {
 
@@ -17,7 +17,7 @@ public class Base64Serialization {
         try {
             return Optional.ofNullable(base64Encode(serializable));
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed serialization", e);
+            log.warn("Failed serialization", e);
             return Optional.empty();
         }
     }
@@ -26,7 +26,7 @@ public class Base64Serialization {
         try {
             return base64Decode(base64String, targetKlazz);
         } catch (IOException | ClassNotFoundException e) {
-            LOGGER.log(Level.WARNING, "Failed deserialiation:", e);
+            log.warn("Failed deserialiation:", e);
             return Optional.empty();
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,9 @@
   <properties>
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <io.freedriver.version>1.0.0-SNAPSHOT</io.freedriver.version>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <lombok.version>1.18.38</lombok.version>
+    <maven.compiler.source>23</maven.compiler.source>
+    <maven.compiler.target>23</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -38,6 +39,10 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.14.0</version>
+        </plugin>
         <!-- Spotless: enforces import order and removes unused imports -->
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
@@ -56,6 +61,19 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
       <!-- Enforce Spotless formatting (including imports) on build -->
       <plugin>
         <groupId>com.diffplug.spotless</groupId>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -10,10 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>autonomy-quarkus</artifactId>
     <properties>
-        <compiler-plugin.version>3.12.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
@@ -120,6 +117,12 @@
             <version>4.8.162</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>
@@ -140,7 +143,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler-plugin.version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/quarkus/src/main/java/io/freedriver/autonomy/async/BaseService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/async/BaseService.java
@@ -1,17 +1,17 @@
 package io.freedriver.autonomy.async;
 
 import java.time.Duration;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public abstract class BaseService {
-    protected abstract Logger getLogger();
     protected void wait(Duration duration) {
-        getLogger().info("Waiting " + duration.toMillis() +"ms");
+        log.info("Waiting {}ms", duration.toMillis());
         try {
             Thread.sleep(duration.toMillis());
         } catch (InterruptedException e) {
-            getLogger().log(Level.SEVERE, "Failed wait: ", e);
+            log.error("Failed wait: ", e);
         }
     }
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/async/EventInitializationService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/async/EventInitializationService.java
@@ -10,8 +10,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import io.freedriver.autonomy.event.input.joystick.jstest.AllJoysticks;
 import io.freedriver.autonomy.jpa.entity.event.input.joystick.JoystickEvent;
@@ -26,11 +24,11 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 
 @ApplicationScoped
+@Slf4j
 public class EventInitializationService extends BaseService {
-
-    private static final Logger LOGGER = Logger.getLogger(EventInitializationService.class.getName());
 
     private final Map<VEDirectReader, Future<Boolean>> devicesInOperation = new ConcurrentHashMap<>();
     private final Map<Path, Future<Boolean>> sbmsUnits =  new ConcurrentHashMap<>();
@@ -63,14 +61,14 @@ public class EventInitializationService extends BaseService {
     }
 
     private void initSimpleAliasMonitor() {
-        LOGGER.info("Initializing SimpleAliasMonitor.");
+        log.info("Initializing SimpleAliasMonitor.");
         pool.submit(() -> {
             simpleAliasService.refreshAnalogPins();
         });
     }
 
     private void initSBMSMonitor() {
-        LOGGER.info("Initializing SBMSMonitor.");
+        log.info("Initializing SBMSMonitor.");
         pool.submit(() -> {
             while (true) {
                 try {
@@ -78,7 +76,7 @@ public class EventInitializationService extends BaseService {
                     SBMS0Finder.findSBMS0Units()
                             .forEach(this::addSBMS);
                 } catch (Exception e) {
-                    LOGGER.log(Level.WARNING, "Couldn't init SBMS0 units", e);
+                    log.warn("Couldn't init SBMS0 units", e);
                 }
             }
         });
@@ -107,9 +105,9 @@ public class EventInitializationService extends BaseService {
                         SBMS0Finder.open(unit)
                                 .forEach(this::fireSBMS0Message);
                     } catch (Exception e) {
-                        LOGGER.log(Level.WARNING, "Failed to stream messages: ", e);
+                        log.warn("Failed to stream messages: ", e);
                         Duration waitingPeriod = Duration.ofMinutes(1);
-                        LOGGER.info("Blacklisting SBMS " + unit + " for " + waitingPeriod.toMillis() + "ms");
+                        log.info("Blacklisting SBMS " + unit + " for " + waitingPeriod.toMillis() + "ms");
                         sbmsUnitsDead.put(unit, Instant.now().plus(waitingPeriod));
                     }
                     sbmsUnits.remove(unit);
@@ -120,7 +118,7 @@ public class EventInitializationService extends BaseService {
     }
 
     private boolean initVEDirectMonitor() {
-        LOGGER.info("Initializing VEDirectMonitor.");
+        log.info("Initializing VEDirectMonitor.");
         while (true) {
             try {
                 deviceService.allDevices()
@@ -128,12 +126,12 @@ public class EventInitializationService extends BaseService {
                         .forEach(this::initVEDirectDevice);
                 break;
             } catch (Exception e) {
-                LOGGER.log(Level.SEVERE, "Couldn't iterate over VEDirectDevices:", e);
+                log.error("Couldn't iterate over VEDirectDevices:", e);
                 wait(Duration.of(5, ChronoUnit.SECONDS));
             }
 
         }
-        LOGGER.info("VEDirectMonitor initialized.");
+        log.info("VEDirectMonitor initialized.");
         return true;
     }
 
@@ -147,7 +145,7 @@ public class EventInitializationService extends BaseService {
     }
 
     private synchronized void initVEDirectDevice(final VEDirectReader veDirectDevice) {
-        LOGGER.info("Initializing VEDirectDevice: " + veDirectDevice.toString());
+        log.info("Initializing VEDirectDevice: " + veDirectDevice.toString());
         devicesInOperation.put(veDirectDevice, pool.submit(() -> {
             veDirectDevice.readAsMessages()
                     .forEach(this::fireVEDirectMessage);
@@ -156,7 +154,7 @@ public class EventInitializationService extends BaseService {
     }
 
     public void initJoystickMonitor() {
-        LOGGER.info("Initializing JoystickMonitor.");
+        log.info("Initializing JoystickMonitor.");
         allJoysticks = new AllJoysticks(pool, this::fireJSTestEvent);
         pool.submit(() -> allJoysticks.poll());
     }
@@ -164,23 +162,23 @@ public class EventInitializationService extends BaseService {
     public void fireJSTestEvent(JSTestEvent jsTestEvent) {
         if (jsTestEvent.getMetadata().getTitle() != null) {
             try {
-                LOGGER.finest("Firing JSTestEvent " + jsTestEvent);
+                log.trace("Firing JSTestEvent " + jsTestEvent);
                 joystickEvents.fire(new JoystickEvent(Instant.now().toEpochMilli(), jsTestEvent));
             } catch (Exception e) {
-                LOGGER.log(Level.WARNING, "Failed to fire JoystickEvent: " + jsTestEvent, e);
+                log.warn("Failed to fire JoystickEvent: " + jsTestEvent, e);
             }
         } else {
             // TODO: This is a workaround for a bug. Fix the bug.
-            LOGGER.warning("JSTestEvent ignored as it contains no subject: " + jsTestEvent);
+            log.warn("JSTestEvent ignored as it contains no subject: " + jsTestEvent);
         }
     }
 
     private synchronized void fireSBMS0Message(SBMSMessage sbmsMessage) {
         try {
-            LOGGER.finest("Firing SBMSMessage " + sbmsMessage);
+            log.trace("Firing SBMSMessage " + sbmsMessage);
             sbmsEvents.fire(sbmsMessage);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to fire SBMSMessage: " + sbmsMessage, e);
+            log.warn("Failed to fire SBMSMessage: " + sbmsMessage, e);
         }
     }
 
@@ -188,12 +186,8 @@ public class EventInitializationService extends BaseService {
         try {
             veDirectEvents.fire(veDirectMessage);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to fire VEDirectMessage: " + veDirectMessage, e);
+            log.warn("Failed to fire VEDirectMessage: " + veDirectMessage, e);
         }
     }
 
-    @Override
-    protected Logger getLogger() {
-        return LOGGER;
-    }
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/async/VEDirectDeviceService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/async/VEDirectDeviceService.java
@@ -5,17 +5,16 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import io.freedriver.electrodacus.sbms.SBMS0Finder;
 import io.freedriver.victron.VEDirectReader;
 import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.slf4j.Slf4j;
 
 @ApplicationScoped
+@Slf4j
 public class VEDirectDeviceService extends BaseService {
-    private static final Logger LOGGER = Logger.getLogger(VEDirectDeviceService.class.getName());
     private static final Set<VEDirectReader> ALL_DEVICES = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     public synchronized Stream<VEDirectReader> allDevices() {
@@ -24,7 +23,7 @@ public class VEDirectDeviceService extends BaseService {
                     .filter(this::veDeviceInactive)
                     .forEach(ALL_DEVICES::add);
         } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "Couldn't iterate over VEDirectDevices:", e);
+            log.error("Couldn't iterate over VEDirectDevices:", e);
         }
         return ALL_DEVICES.stream();
     }
@@ -35,8 +34,4 @@ public class VEDirectDeviceService extends BaseService {
                 .orElse(true);
     }
 
-    @Override
-    protected Logger getLogger() {
-        return LOGGER;
-    }
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/async/XMLVoid.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/async/XMLVoid.java
@@ -2,14 +2,13 @@ package io.freedriver.autonomy.async;
 
 import java.io.File;
 import java.util.Optional;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import lombok.extern.slf4j.Slf4j;
 import org.w3c.dom.Document;
 
+@Slf4j
 public class XMLVoid {
-    public static final Logger LOGGER = Logger.getLogger(XMLVoid.class.getName());
     public static void main(String[] args) {
         if (args.length >= 2) {
             openFile(new File(args[0]))
@@ -31,7 +30,7 @@ public class XMLVoid {
         try {
             return Optional.of(dbf.newDocumentBuilder().parse(xmlFile));
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, e, () -> "Couldn't open file");
+            log.error("Couldn't open file", e);
             return Optional.empty();
         }
     }

--- a/quarkus/src/main/java/io/freedriver/autonomy/hrorm/mock/InterfaceBuilderParadigm.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/hrorm/mock/InterfaceBuilderParadigm.java
@@ -8,10 +8,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.logging.Logger;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class InterfaceBuilderParadigm<ENTITY> {
-    private static final Logger LOGGER = Logger.getLogger(InterfaceBuilderParadigm.class.getName());
 
     private final Class<ENTITY> interfaceClass;
     private final List<ColumnConfiguration<ENTITY, ?>> columns = new ArrayList<>();
@@ -80,8 +81,8 @@ public class InterfaceBuilderParadigm<ENTITY> {
     }
 
     private void testGetter(ColumnConfiguration<ENTITY,?> columnDefinition, ENTITY entity) {
-        LOGGER.info("Fetching column value \""+columnDefinition.getColumnName()+"\" from " + columnDefinition.getInterfaceClass().getSimpleName());
-        LOGGER.info("Found " + String.valueOf(columnDefinition.getGetter().apply(entity)));
+        log.info("Fetching column value \""+columnDefinition.getColumnName()+"\" from " + columnDefinition.getInterfaceClass().getSimpleName());
+        log.info("Found " + String.valueOf(columnDefinition.getGetter().apply(entity)));
     }
 
     /*
@@ -93,7 +94,7 @@ public class InterfaceBuilderParadigm<ENTITY> {
 
         // Not needed here- just for logging.
         Method m = findMethodOfGetterFunction(interfaceClass, entityColumn.getGetter());
-        LOGGER.info("Entity column " + entityColumn.getColumnName() + " refers to field/getter " + m.getName() +
+        log.info("Entity column " + entityColumn.getColumnName() + " refers to field/getter " + m.getName() +
                 " which returns " + m.getReturnType().toString() + " (expected "+entityColumn.getFieldClass().toString()+")");
 
         /*

--- a/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/jsonlink/SimpleAliasHandler.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/jsonlink/SimpleAliasHandler.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import io.freedriver.autonomy.jaxrs.endpoint.SimpleAliasApi;
@@ -18,13 +17,14 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import lombok.extern.slf4j.Slf4j;
 
 @RequestScoped
 @Path(SimpleAliasApi.ROOT)
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
+@Slf4j
 public class SimpleAliasHandler implements SimpleAliasApi {
-    private static final Logger LOGGER = Logger.getLogger(SimpleAliasHandler.class.getName());
 
     @Inject
     ConnectorService connectorService;
@@ -34,13 +34,13 @@ public class SimpleAliasHandler implements SimpleAliasApi {
 
     @Override
     public List<UUID> getBoards() {
-        LOGGER.fine("Getting boards");
+        log.debug("Getting boards");
         return connectorService.getConnectedBoards();
     }
 
     @Override
     public AliasView getState(UUID boardId) throws IOException {
-        LOGGER.fine("Getting state of " + boardId);
+        log.debug("Getting state of " + boardId);
         return simpleAliasService.makeView(boardId);
     }
 

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorService.java
@@ -6,8 +6,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,13 +17,14 @@ import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
 import io.freedriver.jsonlink.jackson.schema.v1.Request;
 import io.freedriver.jsonlink.jackson.schema.v1.Response;
 import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * The service by which we interact with connectors.
  */
 @ApplicationScoped
+@Slf4j
 public class ConnectorService extends ConnectorServiceCommon {
-    private static final Logger LOGGER = Logger.getLogger(ConnectorService.class.getName());
     //private static final List<Connector> ACTIVE_CONNECTORS = new ArrayList<>();
     private static final Path CONFIG_PATH = Paths.get(System.getProperty("user.home"), ".config/autonomy");
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
@@ -37,7 +36,7 @@ public class ConnectorService extends ConnectorServiceCommon {
         try {
             voidCompletableFuture.get();
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to wait for completion of connector", e);
+            log.warn("Failed to wait for completion of connector", e);
         }
     }
 

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorServiceCommon.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorServiceCommon.java
@@ -10,8 +10,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,13 +21,14 @@ import io.freedriver.jsonlink.jackson.schema.v1.Request;
 import io.freedriver.jsonlink.jackson.schema.v1.Response;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.WebApplicationException;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * The service by which we interact with connectors.
  */
 @ApplicationScoped
+@Slf4j
 public class ConnectorServiceCommon {
-    private static final Logger LOGGER = Logger.getLogger(ConnectorServiceCommon.class.getName());
     private static final List<Connector> ACTIVE_CONNECTORS = new ArrayList<>();
     private static final Path CONFIG_PATH = Paths.get(System.getProperty("user.home"), ".config/autonomy");
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
@@ -75,7 +74,7 @@ public class ConnectorServiceCommon {
         try {
             voidCompletableFuture.get();
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to wait for completion of connector", e);
+            log.warn("Failed to wait for completion of connector", e);
         }
     }
 

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/JoystickEventCrudService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/JoystickEventCrudService.java
@@ -1,8 +1,6 @@
 package io.freedriver.autonomy.service;
 
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import io.freedriver.autonomy.jpa.entity.event.input.joystick.JoystickEvent;
 import io.freedriver.autonomy.service.crud.EventCrudService;
@@ -10,17 +8,18 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Default;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 
 @ApplicationScoped
+@Slf4j
 public class JoystickEventCrudService extends EventCrudService<JoystickEvent> {
-    private static final Logger LOGGER = Logger.getLogger(JoystickEventCrudService.class.getName());
 
     @Transactional
     public synchronized void actOnJoystickEvent(@Observes @Default JoystickEvent joystickEvent) throws IOException {
         try {
             persist(joystickEvent);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Exception persisting joystickEvent: " + e.getClass().getName()+": " + e.getMessage());
+            log.warn("Exception persisting joystickEvent: " + e.getClass().getName()+": " + e.getMessage());
         }
     }
 

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/ReportingService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/ReportingService.java
@@ -4,14 +4,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.slf4j.Slf4j;
 
 @ApplicationScoped
+@Slf4j
 public class ReportingService {
-    private static final Logger LOGGER = Logger.getLogger(ReportingService.class.getName());
     private final Map<String, Instant> lastReportedMap = new ConcurrentHashMap<>();
 
     public synchronized <E> void update(String key, Runnable runnable, Duration every) {
@@ -22,7 +21,7 @@ public class ReportingService {
                 lastReportedMap.put(key, Instant.now());
                 runnable.run();
             } catch (Exception e) {
-                LOGGER.log(Level.WARNING, "Error reporting " + key, e);
+                log.warn("Error reporting " + key, e);
             }
         }
     }

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/RestartOnHashChangeService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/RestartOnHashChangeService.java
@@ -12,18 +12,17 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import io.freedriver.base.util.crypt.CryptUtils;
 import io.freedriver.base.util.crypt.HashAlgorithms;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import lombok.extern.slf4j.Slf4j;
 
 @ApplicationScoped
+@Slf4j
 public class RestartOnHashChangeService {
-    private static final Logger LOGGER = Logger.getLogger(RestartOnHashChangeService.class.getName());
 
     public static final String HASH_CHANGE_PROPERTY = "restartOn";
     public static final String HASH_CHANGE_COMMAND = "restartCommand";
@@ -44,7 +43,7 @@ public class RestartOnHashChangeService {
         if (comparisonPath.isPresent() && restartCommand.isPresent()) {
             hashChangeLoop(comparisonPath.get(), restartCommand.get());
         } else {
-            LOGGER.warning(
+            log.warn(
                     (comparisonPath.isEmpty() ? "No " + HASH_CHANGE_PROPERTY + " property; " : "") +
                         (restartCommand.isEmpty() ? "No " + HASH_CHANGE_COMMAND + " property; " : "") +
                             " service disabled.");
@@ -53,17 +52,17 @@ public class RestartOnHashChangeService {
 
     private void hashChangeLoop(Path path, String command) {
         POOL.submit(() -> {
-            LOGGER.info("Service started.");
+            log.info("Service started.");
             while (continueTrying) {
                 try {
                     waitFor(INTERVAL);
                     boolean hashChanged = checkHashChange(path);
                     if (hashChanged) {
-                        LOGGER.info("Hash changed. Initializing restart.");
+                        log.info("Hash changed. Initializing restart.");
                         continueTrying = (runRestartCommand(command) == 0);
                     }
                 } catch (IOException | InterruptedException e) {
-                    LOGGER.log(Level.WARNING, "Looping error", e);
+                    log.warn("Looping error", e);
                 }
             }
             System.exit(0);
@@ -83,12 +82,12 @@ public class RestartOnHashChangeService {
         FileTime fileTime = Files.getLastModifiedTime(path);
         Instant modified = fileTime.toInstant();
         if (lastModified == null) {
-            LOGGER.info("Last modified: " + DateTimeFormatter.ISO_DATE_TIME.format(modified));
+            log.info("Last modified: " + DateTimeFormatter.ISO_DATE_TIME.format(modified));
             lastModified = modified;
             lastHash = hash(path);
         }
         if (modified.isAfter(lastModified)) {
-            LOGGER.info("Last modified changed: " + DateTimeFormatter.ISO_DATE_TIME.format(modified));
+            log.info("Last modified changed: " + DateTimeFormatter.ISO_DATE_TIME.format(modified));
             String currentHash = hash(path);
             return !Objects.equals(lastHash, currentHash);
         }

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
@@ -18,8 +18,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -52,11 +50,12 @@ import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Default;
 import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import org.infinispan.Cache;
 
 @ApplicationScoped
+@Slf4j
 public class SimpleAliasService  {
-    private static final Logger LOGGER = Logger.getLogger(SimpleAliasService.class.getName());
 
     private static Path HISTORY_FILE = DirectoryProviders.CONFIG
             .getProvider()
@@ -132,7 +131,7 @@ public class SimpleAliasService  {
                 }
                 waitFor(Duration.ofMillis(500));
             } catch (IOException | InterruptedException e) {
-                LOGGER.log(Level.WARNING, "Couldn't cache Analog Pin State. ", e);
+                log.warn("Couldn't cache Analog Pin State. ", e);
             }
         }
     }
@@ -147,7 +146,7 @@ public class SimpleAliasService  {
                 sendAnalogSensorEvents(mapping, response);
                 return true;
             } catch (Exception e) {
-                LOGGER.log(Level.WARNING, "Couldn't cache Analog Pin State. ", e);
+                log.warn("Couldn't cache Analog Pin State. ", e);
                 return false;
             }
         });
@@ -258,7 +257,7 @@ public class SimpleAliasService  {
                             speak(analogAlert, percentages);
                         }
                     } else {
-                        LOGGER.warning("Couldn't process AnalogAlert- missing mappings. " + analogAlert);
+                        log.warn("Couldn't process AnalogAlert- missing mappings. " + analogAlert);
                     }
                 });
 
@@ -268,8 +267,8 @@ public class SimpleAliasService  {
     }
 
     private void speak(AnalogAlert analogAlert, Map<String, Double> percentages) {
-        LOGGER.info("AnalogAlert qualified: " + analogAlert);
-        LOGGER.info("Percentages: \n" + percentages.entrySet()
+        log.info("AnalogAlert qualified: " + analogAlert);
+        log.info("Percentages: \n" + percentages.entrySet()
                 .stream()
                 .map(e -> e.getKey() + ": " + e.getValue())
                 .collect(Collectors.joining("\n")));
@@ -316,7 +315,7 @@ public class SimpleAliasService  {
                 );
             }
         } catch (IOException ioe) {
-            LOGGER.log(Level.WARNING, "Couldn't read sensor history file", ioe);
+            log.warn("Couldn't read sensor history file", ioe);
         }
         return sensorHistory;
     }
@@ -325,7 +324,7 @@ public class SimpleAliasService  {
         try {
             ObjectMapperContextResolver.getMapper().writeValue(HISTORY_FILE.toFile(), sensorHistory);
         } catch (IOException ioe) {
-            LOGGER.log(Level.WARNING, "Couldn't write sensor history file", ioe);
+            log.warn("Couldn't write sensor history file", ioe);
         }
     }
 
@@ -501,8 +500,8 @@ public class SimpleAliasService  {
     public Response setState(UUID boardId, Map<String, Boolean> desiredState) throws IOException {
         Mapping mapping = getMapping(boardId);
         if (!desiredState.isEmpty()) {
-            LOGGER.info("Setting states:");
-            desiredState.forEach((k, v) -> LOGGER.info(k+": " + (v ? "true":"false")));
+            log.info("Setting states:");
+            desiredState.forEach((k, v) -> log.info(k+": " + (v ? "true":"false")));
 
             // TODO: Remove
             //return cacheBoardDigitalState(boardId, connectorService
@@ -549,7 +548,7 @@ public class SimpleAliasService  {
                         .getMappings()
                         .forEach(mapping -> handleJoystickEvent(joystickEvent, mapping));
             } catch (Exception e) {
-                LOGGER.log(Level.WARNING, "Failed to observe JoystickEvent: ", e);
+                log.warn("Failed to observe JoystickEvent: ", e);
             }
         }
     }
@@ -580,7 +579,7 @@ public class SimpleAliasService  {
         // Read Analog pins
         //request.analogRead(mapping.getAnalogSensors().stream().map(AnalogSensor::asAnalogRead));
 
-        LOGGER.finest(request.toString());
+        log.trace(request.toString());
 
         cacheBoardState(mapping, connectorService.send(mapping.getConnectorId(), request));
         //cacheBoardDigitalState(mapping.getConnectorId(), connectorService.send(mapping.getConnectorId(), request).getDigital());

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/SpeechService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/SpeechService.java
@@ -7,7 +7,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import io.freedriver.autonomy.jpa.entity.event.speech.SpeechEvent;
@@ -16,10 +15,11 @@ import io.freedriver.autonomy.service.crud.JPACrudService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 
 @ApplicationScoped
+@Slf4j
 public class SpeechService extends JPACrudService<SpeechEvent> {
-    private static final Logger LOGGER = Logger.getLogger(SpeechService.class.getName());
 
     private static final Duration LIMIT = Duration.ofDays(1);
 
@@ -76,7 +76,7 @@ public class SpeechService extends JPACrudService<SpeechEvent> {
     private synchronized void speak(SpeechEvent event) {
         if (shouldActOnEvent(event)) {
             // Festival.speak(event.getText());
-            LOGGER.info("SPEAK: " + event.getText());
+            log.info("SPEAK: " + event.getText());
             recentEvents.add(event);
             recentEvents = recentEvents.stream()
                     .filter(previousEvent -> Instant.ofEpochMilli(previousEvent.getTimestamp())

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/crud/EventCrudService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/crud/EventCrudService.java
@@ -4,8 +4,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import io.freedriver.autonomy.jpa.entity.event.Event;
@@ -14,10 +12,10 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.Root;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 
-
+@Slf4j
 public abstract class EventCrudService<E extends Event> extends JPACrudService<E> {
-    private final Logger LOGGER = Logger.getLogger(getClass().getName());
 
     public static Instant getStartOfDay() {
         LocalDateTime localDateTime = LocalDateTime.now().toLocalDate().atStartOfDay();
@@ -47,7 +45,7 @@ public abstract class EventCrudService<E extends Event> extends JPACrudService<E
 
     @Transactional
     public int applyTTL(Duration duration) {
-        LOGGER.log(Level.FINEST, "Applying TTL");
+        log.trace("Applying TTL");
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaDelete<E> delete = cb.createCriteriaDelete(getEntityClass());
         Root<E> root = delete.from(getEntityClass());

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/crud/TTLEnforcementService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/crud/TTLEnforcementService.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import io.freedriver.autonomy.Autonomy;
 import io.freedriver.autonomy.jaxrs.ObjectMapperContextResolver;
@@ -19,15 +17,16 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This service enforces TTLs on all Event data.
  * TODO: Ask each Event service what their oldest data is like and plan TTL updates instead of polling
  */
 @ApplicationScoped
+@Slf4j
 public class TTLEnforcementService {
     private static final Duration POLL_DURATION = Duration.ofSeconds(1);
-    private final Logger LOGGER = Logger.getLogger(getClass().getName());
 
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
@@ -62,11 +61,11 @@ public class TTLEnforcementService {
             });
             return continueTTLEnforcement;
         }, POLL_DURATION, this::logTTLException);
-        LOGGER.info("Shut down TTL Enforcement.");
+        log.info("Shut down TTL Enforcement.");
     }
 
     private boolean logTTLException(Throwable throwable) {
-        LOGGER.log(Level.WARNING, "Couldn't enforce TTL: ", throwable);
+        log.warn("Couldn't enforce TTL: ", throwable);
         return true;
     }
 
@@ -78,9 +77,9 @@ public class TTLEnforcementService {
     private void applyTTLToEventService(Duration ttl, EventCrudService<?> eventCrudService) {
         try {
             int culled = eventCrudService.applyTTL(ttl);
-            LOGGER.info("Culled " + culled + " from " + eventCrudService.getClass().getSimpleName());
+            log.info("Culled " + culled + " from " + eventCrudService.getClass().getSimpleName());
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Could not apply TTL to "+eventCrudService.getClass().getSimpleName()+": ", e);
+            log.warn("Could not apply TTL to "+eventCrudService.getClass().getSimpleName()+": ", e);
         }
     }
 
@@ -109,7 +108,7 @@ public class TTLEnforcementService {
             Mappings mappings = getMappings();
             return Duration.of(mappings.getEventTTL(), mappings.getEventTTLUnit());
         } catch (IOException ioe) {
-            LOGGER.log(Level.WARNING, "Cannot read TTL:", ioe);
+            log.warn("Cannot read TTL:", ioe);
             return Duration.ofDays(7);
         }
 

--- a/quarkus/src/main/java/io/freedriver/autonomy/util/Benchmark.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/util/Benchmark.java
@@ -2,25 +2,21 @@ package io.freedriver.autonomy.util;
 
 import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class Benchmark {
-    private static final Logger LOGGER = Logger.getLogger(Benchmark.class.getName());
 
     public static final String TIME_PLACEHOLDER = "{execution_time}";
-    public static final Benchmark INFO = new Benchmark(Level.INFO);
-    public static final Benchmark DEBUG = new Benchmark(Level.FINEST);
+    public static final Benchmark INFO = new Benchmark((m, o) -> log.info(m, o));
+    public static final Benchmark DEBUG = new Benchmark((m, o) -> log.trace(m, o));
 
     private final BiConsumer<String, Object[]> logConsumer;
 
     public Benchmark(BiConsumer<String, Object[]> logConsumer) {
         this.logConsumer = logConsumer;
-    }
-
-    public Benchmark(Level level) {
-        this((m, o) -> LOGGER.log(level, m, o));
     }
 
     public void log(String message, long time, Object... args) {

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageActor.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageActor.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import io.freedriver.autonomy.cdi.qualifier.VEProduct;
@@ -20,10 +19,11 @@ import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 
 @ApplicationScoped
+@Slf4j
 public class VEDirectMessageActor {
-    private static final Logger LOGGER = Logger.getLogger(VEDirectMessageActor.class.getName());
     private static final Map<VictronDevice, VEDirectMessage> lastMessage = new ConcurrentHashMap<>();
 
     @Inject
@@ -63,7 +63,7 @@ public class VEDirectMessageActor {
                 .forEach(field ->
                         reportingService.update(
                                 field.getFieldName(veDirectMessage),
-                                () -> LOGGER.info(field.getFieldName(veDirectMessage) + ": " + field.getMessage(veDirectMessage)),
+                                () -> log.info(field.getFieldName(veDirectMessage) + ": " + field.getMessage(veDirectMessage)),
                                 field.getInterval(veDirectMessage)));
     }
 
@@ -76,7 +76,7 @@ public class VEDirectMessageActor {
                                 lastMessage.get(product),
                                 veDirectMessage));
         } else {
-            LOGGER.info(product + " VE.Direct initial field values: \n" +
+            log.info(product + " VE.Direct initial field values: \n" +
                     VEDirectMessageChange.allValues(veDirectMessage));
         }
         lastMessage.put(product, veDirectMessage);
@@ -95,7 +95,7 @@ public class VEDirectMessageActor {
     }
 
     private void compareMessageField(VEDirectMessageChange field, VEDirectMessage oldMessage, VEDirectMessage newMessage) {
-        field.test(oldMessage, newMessage, LOGGER::info);
+        field.test(oldMessage, newMessage, log::info);
     }
 
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageService.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.Set;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -37,7 +36,6 @@ import org.infinispan.Cache;
 
 @ApplicationScoped // TODO EventService
 public class VEDirectMessageService extends EventCrudService<VEDirectMessage> {
-    private static final Logger LOGGER = Logger.getLogger(VEDirectMessageService.class.getSimpleName());
 
     @Inject
     AttributeCache maxCache;


### PR DESCRIPTION
Combined autonomy equivalent of freedriver #13 (Lombok + records) and #14 (GitHub Actions CI).

## Changes

### Java 23 + Lombok (freedriver #13)
- Bump `maven.compiler.source/target` to **23** (root + quarkus)
- Add `lombok.version` **1.18.38** and parent `maven-compiler-plugin` **3.14.0** with lombok `annotationProcessorPaths`
- Manage lombok + slf4j-api in `autonomy-bom`; add lombok `provided` to api/jpa/quarkus
- Convert immutables to **records**:
  - `VoltageSoc`
  - `FailedJoystick` (path-only equals/hashCode preserved)
  - `ControllerHistoryView`
  - `ControllerStateView` (computed getters kept as methods)
- Replace `java.util.logging` with Lombok **`@Slf4j`** across api, jpa, and quarkus

### GitHub Actions CI (freedriver #14)
- Add `.github/workflows/ci.yml`: ubuntu-latest, Temurin JDK 23, `mvn --batch-mode --no-transfer-progress verify`

## Verification
- `mvn spotless:apply` applied before commit
- `mvn verify -pl bom,jpa,api -am` passes locally
- Note: `autonomy-quarkus` already fails to compile on `master` (missing `VEDirectReader`, `io.freedriver.base.util.tedious.Loops`) — pre-existing; full reactor `verify` will need those freedriver deps resolved separately

## Stack position
Base PR on `master`. After merge, rebase the feature stack (`chore/remove-sbms` → `feat/event-sources` → …) onto updated master.