### PR TITLE
chore: fix full reactor build (JPA metamodel + Quarkus 3 native IT)

### DIFF
--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -97,7 +97,7 @@
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <!--<compilerArguments>-Aeclipselink.persistencexml=${project.basedir}/eclipselink-persistence.xml</compilerArguments>-->
+                            <compilerArguments>-Aeclipselink.persistencexml=${project.basedir}/src/main/resources/META-INF/persistence.xml</compilerArguments>
                             <processors>
                                 <processor>org.eclipse.persistence.internal.jpa.modelgen.CanonicalModelProcessor</processor>
                             </processors>
@@ -113,6 +113,29 @@
                         <scope>compile</scope>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <!-- Add the generated metamodel sources (from eclipselink processor) so they get compiled into the jpa artifact.
+                 This is required for full reactor builds that compile quarkus (which uses the static metamodel _ classes
+                 for Criteria queries in VEDirectMessageService, EventCrudService etc.). Without this, quarkus compile fails
+                 with "cannot find symbol" for Event_ / VEDirectMessage_ . -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>add-metamodel-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/meta-model</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <!-- We want quarkus to find entities on its own, not use persistence.xml -->
             <!-- Yet we also want eclipselink to generate the static metamodel. -->

--- a/quarkus/src/test/java/io/freedriver/autonomy/NativeGreetingResourceIT.java
+++ b/quarkus/src/test/java/io/freedriver/autonomy/NativeGreetingResourceIT.java
@@ -1,8 +1,8 @@
 package io.freedriver.autonomy;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeGreetingResourceIT extends GreetingResourceTest {
 
     // Execute the same tests but in native mode.


### PR DESCRIPTION
**Summary**

- `jpa/pom.xml`: Fix JPA static metamodel generation (eclipselink `CanonicalModelProcessor`). 
  The processor was skipping generation (warning: "The persistence xml file [META-INF/persistence.xml] was not found. NO GENERATION will occur!!") because no location was provided to it, and the generated sources dir was never added to the compile source roots. 
  This meant the `*_` metamodel classes (`VEDirectMessage_`, `Event_` etc. used for type-safe Criteria in the quarkus module) were never produced.
  Fixed by:
  * Passing `-Aeclipselink.persistencexml=.../src/main/resources/META-INF/persistence.xml` to the processor.
  * Adding `build-helper-maven-plugin` (in `generate-sources`) to register `target/generated-sources/meta-model`.
  Now the classes are generated and compiled into the jpa artifact (verified: `VEDirectMessage_.class` etc. present after `mvn compile -pl jpa`).

- `quarkus/src/test/java/io/freedriver/autonomy/NativeGreetingResourceIT.java`: Update from the Quarkus 1/2-era `@NativeImageTest` (class `io.quarkus.test.junit.NativeImageTest`, removed in Quarkus 3) to the current `@QuarkusIntegrationTest`.

These were uncovered while running a full `mvn clean verify` (including the `quarkus` module) to validate the current state before more revamp work. They were previously invisible because both the GitHub CI and the documented local verify command are still restricted to `-pl bom,jpa,api -am` (see the TODO comment in `.github/workflows/ci.yml` and `autonomy_todo.md`).

**After these changes**
- Full reactor `mvn clean verify -DskipTests` now reaches `BUILD SUCCESS` and the Quarkus build produces the fast-jar layout under `quarkus/target/quarkus-app/`.
- Full verify *with* tests still has runtime/test failures (jackson `RecyclerPool` NoClassDefFound during Quarkus bootstrap in `GreetingResourceTest`, devservices/docker issues for mongo, etc.). These are expected until the remaining items (esp. the VEDirect refactor that unblocks quarkus) land.

**Verification**
- Local: `cd freedriver && mvn install -DskipTests && cd ../autonomy && mvn spotless:apply && mvn clean verify -DskipTests` (full reactor) → BUILD SUCCESS.
- The changes are minimal and targeted at making the existing "full build" path actually work.

Part of the ongoing work to unblock the full reactor / update CI (see `autonomy_todo.md` "Next up" and the revamp stack).