### PR TITLE
Replace Infinispan with local ConcurrentHashMap caches

### DIFF
--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/JoystickEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/JoystickEvent.java
@@ -17,7 +17,7 @@ public class JoystickEvent extends Event {
     private Long number;
 
     @Column(name = "event_value")
-    private Long value;
+    private Long eventValue;
 
     @Column
     private boolean initial;
@@ -29,11 +29,11 @@ public class JoystickEvent extends Event {
     }
 
     public JoystickEvent(long timestamp, GenerationOrigin generationOrigin, String sourceClass,
-                         String sourceId, String eventId, Long number, Long value, boolean initial,
+                         String sourceId, String eventId, Long number, Long eventValue, boolean initial,
                          JoystickEventType joystickEventType) {
         super(timestamp, generationOrigin, sourceClass, sourceId, eventId);
         this.number = number;
-        this.value = value;
+        this.eventValue = eventValue;
         this.initial = initial;
         this.joystickEventType = joystickEventType;
     }
@@ -60,12 +60,12 @@ public class JoystickEvent extends Event {
         this.number = number;
     }
 
-    public Long getValue() {
-        return value;
+    public Long getEventValue() {
+        return eventValue;
     }
 
-    public void setValue(Long value) {
-        this.value = value;
+    public void setEventValue(Long eventValue) {
+        this.eventValue = eventValue;
     }
 
     public boolean isInitial() {
@@ -96,12 +96,12 @@ public class JoystickEvent extends Event {
         JoystickEvent that = (JoystickEvent) o;
         return initial == that.initial &&
                 Objects.equals(number, that.number) &&
-                Objects.equals(value, that.value) &&
+                Objects.equals(eventValue, that.eventValue) &&
                 joystickEventType == that.joystickEventType;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), number, value, initial, joystickEventType);
+        return Objects.hash(super.hashCode(), number, eventValue, initial, joystickEventType);
     }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/JoystickEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/JoystickEvent.java
@@ -16,7 +16,7 @@ public class JoystickEvent extends Event {
     @Column
     private Long number;
 
-    @Column
+    @Column(name = "event_value")
     private Long value;
 
     @Column

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/DoubleValueSensorEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/DoubleValueSensorEvent.java
@@ -15,7 +15,7 @@ import jakarta.persistence.Table;
 @Table
 @Inheritance(strategy = InheritanceType.JOINED)
 public class DoubleValueSensorEvent extends SensorEvent {
-    @Column
+    @Column(name = "event_value")
     private double value;
 
     public DoubleValueSensorEvent() {

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/DoubleValueSensorEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/DoubleValueSensorEvent.java
@@ -16,33 +16,33 @@ import jakarta.persistence.Table;
 @Inheritance(strategy = InheritanceType.JOINED)
 public class DoubleValueSensorEvent extends SensorEvent {
     @Column(name = "event_value")
-    private double value;
+    private double eventValue;
 
     public DoubleValueSensorEvent() {
     }
 
-    public DoubleValueSensorEvent(UUID boardId, String sensorName, double value) {
+    public DoubleValueSensorEvent(UUID boardId, String sensorName, double eventValue) {
         super(boardId, sensorName);
-        this.value = value;
+        this.eventValue = eventValue;
     }
 
-    public DoubleValueSensorEvent(long timestamp, GenerationOrigin generationOrigin, String sourceClass, String sourceId, String eventId, UUID boardId, String sensorName, double value) {
+    public DoubleValueSensorEvent(long timestamp, GenerationOrigin generationOrigin, String sourceClass, String sourceId, String eventId, UUID boardId, String sensorName, double eventValue) {
         super(timestamp, generationOrigin, sourceClass, sourceId, eventId, boardId, sensorName);
-        this.value = value;
+        this.eventValue = eventValue;
     }
 
-    public double getValue() {
-        return value;
+    public double getEventValue() {
+        return eventValue;
     }
 
-    public void setValue(double value) {
-        this.value = value;
+    public void setEventValue(double eventValue) {
+        this.eventValue = eventValue;
     }
 
     @Override
     public String toString() {
         return "FloatValueSensorEvent{" +
-                "value=" + value +
+                "eventValue=" + eventValue +
                 '}';
     }
 
@@ -52,11 +52,11 @@ public class DoubleValueSensorEvent extends SensorEvent {
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         DoubleValueSensorEvent that = (DoubleValueSensorEvent) o;
-        return Double.compare(that.value, value) == 0;
+        return Double.compare(that.eventValue, eventValue) == 0;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), value);
+        return Objects.hash(super.hashCode(), eventValue);
     }
 }

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -84,13 +84,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-core</artifactId>
-            <version>15.0.0.Final</version>
-        </dependency>
-
-
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/AttributeCache.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/AttributeCache.java
@@ -1,18 +1,18 @@
 package io.freedriver.autonomy.cdi;
 
+import java.util.Map;
 import java.util.function.Function;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.metamodel.SingularAttribute;
-import org.infinispan.Cache;
 
 @ApplicationScoped
 public class AttributeCache {
 
     @Inject
     @io.freedriver.autonomy.cdi.qualifier.AttributeCache
-    Cache<SingularAttribute<?, ?>, Object> backingCache;
+    Map<SingularAttribute<?, ?>, Object> backingCache;
 
     @SuppressWarnings("unchecked")
     public <E, T, A extends SingularAttribute<E, T>> T computeIfAbsent(A attribute, Function<A, Object> mappingFunction) {

--- a/quarkus/src/main/java/io/freedriver/autonomy/cdi/provider/CacheProvider.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cdi/provider/CacheProvider.java
@@ -1,11 +1,8 @@
 package io.freedriver.autonomy.cdi.provider;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
+import java.util.concurrent.ConcurrentHashMap;
 
-import io.freedriver.autonomy.Autonomy;
 import io.freedriver.autonomy.cdi.qualifier.AttributeCache;
 import io.freedriver.autonomy.cdi.qualifier.AutonomyCache;
 import io.freedriver.autonomy.cdi.qualifier.ConnectorCache;
@@ -13,114 +10,44 @@ import io.freedriver.autonomy.cdi.qualifier.OneSecondCache;
 import io.freedriver.autonomy.cdi.qualifier.SensorCache;
 import io.freedriver.autonomy.cdi.qualifier.SpeechCache;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
-import jakarta.inject.Inject;
-import org.infinispan.Cache;
-import org.infinispan.configuration.cache.Configuration;
-import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.manager.DefaultCacheManager;
-import org.infinispan.manager.EmbeddedCacheManager;
 
 @ApplicationScoped
 public class CacheProvider {
-    public static final String ONE_SECOND_CACHE = "one_second_cache";
-    public static final String ATTRIBUTE_CACHE = "attribute_cache";
-    public static final String CONNECTOR_CACHE = "connector_cache";
-    public static final String SENSOR_CACHE = "sensor_cache";
-    public static final String SPEECH_CACHE = "speech_cache";
-
-    private final EmbeddedCacheManager embeddedCacheManager = new DefaultCacheManager(true);
-    private Map<String, Configuration> configurations = new HashMap<>();
-
-    @Inject
-    Instance<Configuration> allConfigurations;
 
     @Produces
     @OneSecondCache
-    public <K, V> Cache<K, V> oneSecondCache() {
-        return createCache(ONE_SECOND_CACHE, () -> new ConfigurationBuilder()
-                .locking()
-                .lockAcquisitionTimeout(10, TimeUnit.SECONDS)
-                .expiration()
-                .lifespan(1, TimeUnit.SECONDS)
-                .memory()
-                .maxCount(10000)
-                .build());
+    public <K, V> Map<K, V> oneSecondCache() {
+        return new ConcurrentHashMap<>();
     }
 
     @Produces
     @AttributeCache
-    public <K, V> Cache<K, V> attributeCache() {
-        return createCache(ATTRIBUTE_CACHE, () -> new ConfigurationBuilder()
-                .locking()
-                .lockAcquisitionTimeout(10, TimeUnit.SECONDS)
-                .memory()
-                .maxCount(100)
-                .build());
+    public <K, V> Map<K, V> attributeCache() {
+        return new ConcurrentHashMap<>();
     }
 
     @Produces
     @ConnectorCache
-    public <K, V> Cache<K, V> connectorCache() {
-        return createCache(CONNECTOR_CACHE, () -> new ConfigurationBuilder()
-                .locking()
-                .lockAcquisitionTimeout(10, TimeUnit.SECONDS)
-                .expiration()
-                .lifespan(100, TimeUnit.SECONDS)
-                .memory()
-                .maxCount(1000)
-                .build());
+    public <K, V> Map<K, V> connectorCache() {
+        return new ConcurrentHashMap<>();
     }
-
 
     @Produces
     @SensorCache
-    public <K, V> Cache<K, V> sensorCache() {
-        return createCache(SENSOR_CACHE, () -> new ConfigurationBuilder()
-                .locking()
-                .lockAcquisitionTimeout(10, TimeUnit.SECONDS)
-                .expiration()
-                .lifespan(100, TimeUnit.SECONDS)
-                .memory()
-                .maxCount(1000)
-                .build());
+    public <K, V> Map<K, V> sensorCache() {
+        return new ConcurrentHashMap<>();
     }
-
 
     @Produces
     @AutonomyCache
-    public <K, V> Cache<K, V> autonomyCache() {
-        return createCache(Autonomy.DEPLOYMENT, () -> new ConfigurationBuilder()
-                .locking()
-                .lockAcquisitionTimeout(10, TimeUnit.SECONDS)
-                .expiration()
-                .lifespan(10, TimeUnit.SECONDS)
-                .memory()
-                .maxCount(100)
-                .build());
+    public <K, V> Map<K, V> autonomyCache() {
+        return new ConcurrentHashMap<>();
     }
 
     @Produces
     @SpeechCache
-    public <K, V> Cache<K, V> speechCache() {
-        return createCache(Autonomy.DEPLOYMENT, () -> new ConfigurationBuilder()
-                .locking()
-                .lockAcquisitionTimeout(10, TimeUnit.SECONDS)
-                .expiration()
-                .lifespan(10, TimeUnit.HOURS)
-                .memory()
-                .maxCount(1000)
-                .build());
-    }
-
-
-
-    private synchronized <V, K> Cache<K,V> createCache(String cacheName, Supplier<Configuration> configuration) {
-        return embeddedCacheManager.cacheExists(cacheName)
-                ? embeddedCacheManager.getCache(cacheName)
-                : embeddedCacheManager.createCache(
-                cacheName,
-                configurations.computeIfAbsent(cacheName, (s) -> configuration.get()));
+    public <K, V> Map<K, V> speechCache() {
+        return new ConcurrentHashMap<>();
     }
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
@@ -51,7 +51,6 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Default;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
-import org.infinispan.Cache;
 
 @ApplicationScoped
 @Slf4j
@@ -76,11 +75,11 @@ public class SimpleAliasService  {
 
     @Inject
     @ConnectorCache
-    Cache<PinCoordinate, Boolean> digitalPinCache;
+    Map<PinCoordinate, Boolean> digitalPinCache;
 
     @Inject
     @SensorCache
-    Cache<PinCoordinate, SensorValues> sensorCache;
+    Map<PinCoordinate, SensorValues> sensorCache;
 
     @Inject
     Event<SpeechEvent> speech;

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
@@ -292,7 +292,7 @@ public class SimpleAliasService  {
                         event.setSourceClass(getClass().getName());
                         event.setSourceId(mapping.getConnectorId().toString());
                         event.setEventId("analog/"+analogSensor.getPin().getPin());
-                        event.setValue(analogResponse.getRaw());
+                        event.setEventValue(analogResponse.getRaw());
                         floatValueSensorService.save(event);
                 }));
     }
@@ -553,7 +553,7 @@ public class SimpleAliasService  {
     }
 
     public void handleJoystickEvent(JoystickEvent joystickEvent, Mapping mapping) {
-        String eventId = joystickEvent.getNumber() + ":" + joystickEvent.getValue();
+        String eventId = joystickEvent.getNumber() + ":" + joystickEvent.getEventValue();
         Optional.of(eventId)
                 .map(mapping.getControlMap()::get)
                 .ifPresent(appliances -> toggleAppliances(mapping, appliances));

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageService.java
@@ -3,6 +3,7 @@ package io.freedriver.autonomy.vedirect;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,7 +33,6 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
 import jakarta.transaction.Transactional;
-import org.infinispan.Cache;
 
 @ApplicationScoped // TODO EventService
 public class VEDirectMessageService extends EventCrudService<VEDirectMessage> {
@@ -42,19 +42,19 @@ public class VEDirectMessageService extends EventCrudService<VEDirectMessage> {
 
     @Inject
     @AutonomyCache
-    Cache<CacheKey<VictronDevice, ControllerTimeView>, ControllerTimeView> timeViewCache;
+    Map<CacheKey<VictronDevice, ControllerTimeView>, ControllerTimeView> timeViewCache;
 
     @Inject
     @AutonomyCache
-    Cache<CacheKey<VictronDevice, ControllerHistoryView>, ControllerHistoryView> historyViewCache;
+    Map<CacheKey<VictronDevice, ControllerHistoryView>, ControllerHistoryView> historyViewCache;
 
     @Inject
     @AutonomyCache
-    Cache<LocalDate, Set<VictronDevice>> victronDeviceCache;
+    Map<LocalDate, Set<VictronDevice>> victronDeviceCache;
 
     @Inject
     @OneSecondCache
-    Cache<CacheKey<VictronDevice, VEDirectMessage>, VEDirectMessage> lastMessageCache;
+    Map<CacheKey<VictronDevice, VEDirectMessage>, VEDirectMessage> lastMessageCache;
 
     /* TODO Remove, no support in Quarkus for persistence providers at init
     public void init(@Observes @Initialized(ApplicationScoped.class) Object init) {


### PR DESCRIPTION
**Summary**

Infinispan was used as a local-only embedded cache in front of GPIO pin state and VEDirect query results. That is overkill, and the pinned `infinispan-core` 15.0.0.Final clashed with Quarkus 3.37's `infinispan-commons` 16 (`NoSuchMethodError: Attribute.set`) so the app could not serve `/rest/vedirect/device`.

**Changes**

- Consumers (`SimpleAliasService`, `VEDirectMessageService`, `AttributeCache`) inject `java.util.Map` instead of `org.infinispan.Cache`.
- `CacheProvider` produces `ConcurrentHashMap` instances (same qualifier names). TTL / maxCount from the old Infinispan configs are dropped — these are small in-process maps.
- Remove `infinispan-core` from `quarkus/pom.xml`.

**Verification**

- `mvn -pl quarkus -am package -DskipTests` → BUILD SUCCESS; no Infinispan jars in `quarkus-app/lib`.
- Packaged `quarkus-run.jar` starts (Quarkus 3.37.0, Jackson 2.22 from freedriver #15).
- `GET /` 200, `/rest/config` 200, `/rest/simple` 200 `[]`, `/rest/vedirect/device` 200 `[]` (was 500).

Depends on merged freedriver #15 (jackson-bom) for a clean local boot.