### PR TITLE
Lombok records/builders + freedriver record accessors

### DIFF
--- a/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerHistoryView.java
+++ b/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerHistoryView.java
@@ -1,5 +1,8 @@
 package io.freedriver.autonomy.entity.view;
 
+import lombok.Builder;
+
+@Builder(toBuilder = true)
 public record ControllerHistoryView(
         double maxPanelPower,
         double maxPanelVoltage,

--- a/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerStateView.java
+++ b/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerStateView.java
@@ -1,7 +1,9 @@
 package io.freedriver.autonomy.entity.view;
 
 import io.freedriver.autonomy.jpa.entity.VEDirectMessage;
+import lombok.Builder;
 
+@Builder(toBuilder = true)
 public record ControllerStateView(VEDirectMessage lastMessage) {
 
     public Double getYield() {

--- a/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerTimeView.java
+++ b/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerTimeView.java
@@ -9,22 +9,29 @@ import java.util.Set;
 
 import io.freedriver.victron.StateOfOperation;
 import io.freedriver.victron.vedirect.OffReason;
+import lombok.Builder;
 
-public class ControllerTimeView {
-    private final Map<String, Long> data;
-    private final ChronoUnit unit;
-    private final long secondsPerUnit;
+@Builder(toBuilder = true)
+public record ControllerTimeView(
+        Map<String, Long> data,
+        ChronoUnit unit,
+        long secondsPerUnit) {
+
+    public ControllerTimeView {
+        data = data == null ? new LinkedHashMap<>() : data;
+    }
 
     public ControllerTimeView(Duration duration) {
+        this(new LinkedHashMap<>(), unitFor(duration), unitFor(duration).getDuration().toSeconds());
+    }
+
+    private static ChronoUnit unitFor(Duration duration) {
         if (duration.toSeconds() > 3600) {
-            this.unit = ChronoUnit.HOURS;
+            return ChronoUnit.HOURS;
         } else if (duration.toSeconds() > 60) {
-            this.unit = ChronoUnit.MINUTES;
-        } else {
-            this.unit = ChronoUnit.SECONDS;
+            return ChronoUnit.MINUTES;
         }
-        this.secondsPerUnit = unit.getDuration().toSeconds();
-        this.data = new LinkedHashMap<>();
+        return ChronoUnit.SECONDS;
     }
 
     public ControllerTimeView addMissingMapKeys(Set<StateOfOperation> historicalStates,
@@ -67,17 +74,5 @@ public class ControllerTimeView {
             }
         }
         return this;
-    }
-
-    public Map<String, Long> getData() {
-        return data;
-    }
-
-    public ChronoUnit getUnit() {
-        return unit;
-    }
-
-    public long getSecondsPerUnit() {
-        return secondsPerUnit;
     }
 }

--- a/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerView.java
+++ b/api/src/main/java/io/freedriver/autonomy/entity/view/ControllerView.java
@@ -1,34 +1,12 @@
 package io.freedriver.autonomy.entity.view;
 
 import io.freedriver.victron.VictronDevice;
+import lombok.Builder;
 
-public class ControllerView {
-    private final VictronDevice device;
-
-    private final ControllerTimeView controllerTime;
-    private final ControllerStateView controllerState;
-    private final ControllerHistoryView controllerHistory;
-
-    public ControllerView(VictronDevice device, ControllerTimeView controllerTime, ControllerStateView controllerState, ControllerHistoryView controllerHistory) {
-        this.device = device;
-        this.controllerTime = controllerTime;
-        this.controllerState = controllerState;
-        this.controllerHistory = controllerHistory;
-    }
-
-    public VictronDevice getDevice() {
-        return device;
-    }
-
-    public ControllerTimeView getControllerTime() {
-        return controllerTime;
-    }
-
-    public ControllerStateView getControllerState() {
-        return controllerState;
-    }
-
-    public ControllerHistoryView getControllerHistory() {
-        return controllerHistory;
-    }
+@Builder(toBuilder = true)
+public record ControllerView(
+        VictronDevice device,
+        ControllerTimeView controllerTime,
+        ControllerStateView controllerState,
+        ControllerHistoryView controllerHistory) {
 }

--- a/api/src/main/java/io/freedriver/autonomy/jaxrs/view/AliasView.java
+++ b/api/src/main/java/io/freedriver/autonomy/jaxrs/view/AliasView.java
@@ -4,71 +4,29 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-public class AliasView {
-    Map<String, Boolean> applianceStates = new LinkedHashMap<>();
-    Map<String, Boolean> groupStates = new LinkedHashMap<>();
-    Map<String, Set<String>> groups = new LinkedHashMap<>();
-    Map<String, Double> sensors = new LinkedHashMap<>();
-    Map<String, Double> sensorMins = new LinkedHashMap<>();
-    Map<String, Double> sensorMaxes = new LinkedHashMap<>();
-    Map<String, Double> sensorPercentages = new LinkedHashMap<>();
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record AliasView(
+        Map<String, Boolean> applianceStates,
+        Map<String, Boolean> groupStates,
+        Map<String, Set<String>> groups,
+        Map<String, Double> sensors,
+        Map<String, Double> sensorMins,
+        Map<String, Double> sensorMaxes,
+        Map<String, Double> sensorPercentages) {
+
+    public AliasView {
+        applianceStates = applianceStates == null ? new LinkedHashMap<>() : applianceStates;
+        groupStates = groupStates == null ? new LinkedHashMap<>() : groupStates;
+        groups = groups == null ? new LinkedHashMap<>() : groups;
+        sensors = sensors == null ? new LinkedHashMap<>() : sensors;
+        sensorMins = sensorMins == null ? new LinkedHashMap<>() : sensorMins;
+        sensorMaxes = sensorMaxes == null ? new LinkedHashMap<>() : sensorMaxes;
+        sensorPercentages = sensorPercentages == null ? new LinkedHashMap<>() : sensorPercentages;
+    }
 
     public AliasView() {
-    }
-
-    public Map<String, Boolean> getApplianceStates() {
-        return applianceStates;
-    }
-
-    public void setApplianceStates(Map<String, Boolean> applianceStates) {
-        this.applianceStates = applianceStates;
-    }
-
-    public Map<String, Boolean> getGroupStates() {
-        return groupStates;
-    }
-
-    public void setGroupStates(Map<String, Boolean> groupStates) {
-        this.groupStates = groupStates;
-    }
-
-    public Map<String, Set<String>> getGroups() {
-        return groups;
-    }
-
-    public void setGroups(Map<String, Set<String>> groups) {
-        this.groups = groups;
-    }
-
-    public Map<String, Double> getSensors() {
-        return sensors;
-    }
-
-    public void setSensors(Map<String, Double> sensors) {
-        this.sensors = sensors;
-    }
-
-    public Map<String, Double> getSensorMins() {
-        return sensorMins;
-    }
-
-    public void setSensorMins(Map<String, Double> sensorMins) {
-        this.sensorMins = sensorMins;
-    }
-
-    public Map<String, Double> getSensorMaxes() {
-        return sensorMaxes;
-    }
-
-    public void setSensorMaxes(Map<String, Double> sensorMaxes) {
-        this.sensorMaxes = sensorMaxes;
-    }
-
-    public Map<String, Double> getSensorPercentages() {
-        return sensorPercentages;
-    }
-
-    public void setSensorPercentages(Map<String, Double> sensorPercentages) {
-        this.sensorPercentages = sensorPercentages;
+        this(null, null, null, null, null, null, null);
     }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/EmbeddedEntityBase.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/EmbeddedEntityBase.java
@@ -3,24 +3,21 @@ package io.freedriver.autonomy.jpa.entity;
 import java.io.Serializable;
 
 import io.freedriver.autonomy.jpa.iface.Positional;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+@NoArgsConstructor
 public abstract class EmbeddedEntityBase implements Serializable, Positional {
     private long position = 0;
 
-    protected EmbeddedEntityBase() {
-    }
-
     protected EmbeddedEntityBase(EmbeddedEntityBase base) {
         this.position = base.position;
-    }
-
-    @Override
-    public long getPosition() {
-        return position;
-    }
-
-    @Override
-    public void setPosition(long position) {
-        this.position = position;
     }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/EntityBase.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/EntityBase.java
@@ -1,46 +1,24 @@
 package io.freedriver.autonomy.jpa.entity;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @MappedSuperclass
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+@NoArgsConstructor
 public abstract class EntityBase implements Serializable {
     @Id
     @GeneratedValue
     private Long id;
-
-    public EntityBase() {
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        EntityBase that = (EntityBase) o;
-        return Objects.equals(id, that.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
-    }
-
-    @Override
-    public String toString() {
-        return "EntityBase{" +
-                "id=" + id +
-                '}';
-    }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/VEDirectMessage.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/VEDirectMessage.java
@@ -1,7 +1,6 @@
 package io.freedriver.autonomy.jpa.entity;
 
 import java.time.Instant;
-import java.util.Objects;
 
 import io.freedriver.autonomy.jpa.entity.event.Event;
 import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
@@ -31,6 +30,11 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Table(
         indexes = {
@@ -42,6 +46,11 @@ import jakarta.persistence.Transient;
 )
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
 public class VEDirectMessage extends Event {
 
     @Enumerated(EnumType.STRING)
@@ -97,9 +106,6 @@ public class VEDirectMessage extends Event {
     @Enumerated(EnumType.STRING)
     private OffReason offReason;
 
-    public VEDirectMessage() {
-    }
-
     public VEDirectMessage(long timestamp, GenerationOrigin generationOrigin, String sourceClass, String sourceId, String eventId, VictronProduct productType, RelayState relayState, FirmwareVersion firmwareVersion, String serialNumber, Potential mainVoltage, Current mainCurrent, Potential panelVoltage, Power panelPower, Energy resettableYield, Energy yieldToday, Power maxPowerToday, Energy yieldYesterday, Power maxPowerYesterday, StateOfOperation stateOfOperation, TrackerOperation trackerOperation, LoadOutputState loadOutputState, ErrorCode errorCode, OffReason offReason) {
         super(timestamp, generationOrigin, sourceClass, sourceId, eventId);
         this.productType = productType;
@@ -124,246 +130,55 @@ public class VEDirectMessage extends Event {
 
     public VEDirectMessage(io.freedriver.victron.VEDirectMessage veDirectMessage) {
         this(
-                veDirectMessage.getTimestamp().toEpochMilli(),
+                veDirectMessage.timestamp().toEpochMilli(),
                 GenerationOrigin.NON_HUMAN,
                 io.freedriver.victron.VEDirectMessage.class.getSimpleName(),
-                veDirectMessage.getSerialNumber(),
+                veDirectMessage.serialNumber(),
                 null,
-                veDirectMessage.getProductType(),
-                veDirectMessage.getRelayState(),
-                veDirectMessage.getFirmwareVersion(),
-                veDirectMessage.getSerialNumber(),
-                veDirectMessage.getMainVoltage(),
-                veDirectMessage.getMainCurrent(),
-                veDirectMessage.getPanelVoltage(),
-                veDirectMessage.getPanelPower(),
-                veDirectMessage.getResettableYield(),
-                veDirectMessage.getYieldToday(),
-                veDirectMessage.getMaxPowerToday(),
-                veDirectMessage.getYieldYesterday(),
-                veDirectMessage.getMaxPowerYesterday(),
-                veDirectMessage.getStateOfOperation(),
-                veDirectMessage.getTrackerOperation(),
-                veDirectMessage.getLoadOutputState(),
-                veDirectMessage.getErrorCode(),
-                veDirectMessage.getOffReason()
+                veDirectMessage.productType(),
+                veDirectMessage.relayState(),
+                veDirectMessage.firmwareVersion(),
+                veDirectMessage.serialNumber(),
+                veDirectMessage.mainVoltage(),
+                veDirectMessage.mainCurrent(),
+                veDirectMessage.panelVoltage(),
+                veDirectMessage.panelPower(),
+                veDirectMessage.resettableYield(),
+                veDirectMessage.yieldToday(),
+                veDirectMessage.maxPowerToday(),
+                veDirectMessage.yieldYesterday(),
+                veDirectMessage.maxPowerYesterday(),
+                veDirectMessage.stateOfOperation(),
+                veDirectMessage.trackerOperation(),
+                veDirectMessage.loadOutputState(),
+                veDirectMessage.errorCode(),
+                veDirectMessage.offReason()
         );
-    }
-
-    public VictronProduct getProductType() {
-        return productType;
-    }
-
-    public void setProductType(VictronProduct productType) {
-        this.productType = productType;
-    }
-
-    public RelayState getRelayState() {
-        return relayState;
-    }
-
-    public void setRelayState(RelayState relayState) {
-        this.relayState = relayState;
-    }
-
-    public FirmwareVersion getFirmwareVersion() {
-        return firmwareVersion;
-    }
-
-    public void setFirmwareVersion(FirmwareVersion firmwareVersion) {
-        this.firmwareVersion = firmwareVersion;
-    }
-
-    public String getSerialNumber() {
-        return serialNumber;
-    }
-
-    public void setSerialNumber(String serialNumber) {
-        this.serialNumber = serialNumber;
-    }
-
-    public Potential getMainVoltage() {
-        return mainVoltage;
-    }
-
-    public void setMainVoltage(Potential mainVoltage) {
-        this.mainVoltage = mainVoltage;
-    }
-
-    public Current getMainCurrent() {
-        return mainCurrent;
-    }
-
-    public void setMainCurrent(Current mainCurrent) {
-        this.mainCurrent = mainCurrent;
-    }
-
-    public Potential getPanelVoltage() {
-        return panelVoltage;
-    }
-
-    public void setPanelVoltage(Potential panelVoltage) {
-        this.panelVoltage = panelVoltage;
-    }
-
-    public Power getPanelPower() {
-        return panelPower;
-    }
-
-    public void setPanelPower(Power panelPower) {
-        this.panelPower = panelPower;
-    }
-
-
-    public Energy getResettableYield() {
-        return resettableYield;
-    }
-
-    public void setResettableYield(Energy resettableYield) {
-        this.resettableYield = resettableYield;
-    }
-
-    public Energy getYieldToday() {
-        return yieldToday;
-    }
-
-    public void setYieldToday(Energy yieldToday) {
-        this.yieldToday = yieldToday;
-    }
-
-    public Power getMaxPowerToday() {
-        return maxPowerToday;
-    }
-
-    public void setMaxPowerToday(Power maxPowerToday) {
-        this.maxPowerToday = maxPowerToday;
-    }
-
-    public Energy getYieldYesterday() {
-        return yieldYesterday;
-    }
-
-    public void setYieldYesterday(Energy yieldYesterday) {
-        this.yieldYesterday = yieldYesterday;
-    }
-
-    public Power getMaxPowerYesterday() {
-        return maxPowerYesterday;
-    }
-
-    public void setMaxPowerYesterday(Power maxPowerYesterday) {
-        this.maxPowerYesterday = maxPowerYesterday;
-    }
-
-    public StateOfOperation getStateOfOperation() {
-        return stateOfOperation;
-    }
-
-    public void setStateOfOperation(StateOfOperation stateOfOperation) {
-        this.stateOfOperation = stateOfOperation;
-    }
-
-    public TrackerOperation getTrackerOperation() {
-        return trackerOperation;
-    }
-
-    public void setTrackerOperation(TrackerOperation trackerOperation) {
-        this.trackerOperation = trackerOperation;
-    }
-
-    public ErrorCode getErrorCode() {
-        return errorCode;
-    }
-
-    public void setErrorCode(ErrorCode errorCode) {
-        this.errorCode = errorCode;
-    }
-
-    public LoadOutputState getLoadOutputState() {
-        return loadOutputState;
-    }
-
-    public void setLoadOutputState(LoadOutputState loadOutputState) {
-        this.loadOutputState = loadOutputState;
-    }
-
-    public OffReason getOffReason() {
-        return offReason;
-    }
-
-    public void setOffReason(OffReason offReason) {
-        this.offReason = offReason;
     }
 
     @Transient
     public io.freedriver.victron.VEDirectMessage toNative() {
-        io.freedriver.victron.VEDirectMessage nativeMessage = new io.freedriver.victron.VEDirectMessage();
-        nativeMessage.setTimestamp(Instant.ofEpochMilli(getTimestamp()));
-        nativeMessage.setProductType(getProductType());
-        nativeMessage.setRelayState(getRelayState());
-        nativeMessage.setFirmwareVersion(getFirmwareVersion());
-        nativeMessage.setSerialNumber(getSerialNumber());
-        nativeMessage.setMainVoltage(getMainVoltage());
-        nativeMessage.setMainCurrent(getMainCurrent());
-        nativeMessage.setPanelVoltage(getPanelVoltage());
-        nativeMessage.setPanelPower(getPanelPower());
-        nativeMessage.setStateOfOperation(getStateOfOperation());
-        nativeMessage.setTrackerOperation(getTrackerOperation());
-        nativeMessage.setLoadOutputState(getLoadOutputState());
-        nativeMessage.setErrorCode(getErrorCode());
-        nativeMessage.setOffReason(getOffReason());
-        nativeMessage.setResettableYield(getResettableYield());
-        nativeMessage.setYieldToday(getYieldToday());
-        nativeMessage.setMaxPowerToday(getMaxPowerToday());
-        nativeMessage.setYieldYesterday(getYieldYesterday());
-        nativeMessage.setMaxPowerYesterday(getMaxPowerYesterday());
-        return nativeMessage;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        VEDirectMessage that = (VEDirectMessage) o;
-        return  productType == that.productType &&
-                relayState == that.relayState &&
-                Objects.equals(firmwareVersion, that.firmwareVersion) &&
-                Objects.equals(serialNumber, that.serialNumber) &&
-                Objects.equals(mainVoltage, that.mainVoltage) &&
-                Objects.equals(mainCurrent, that.mainCurrent) &&
-                Objects.equals(panelVoltage, that.panelVoltage) &&
-                Objects.equals(panelPower, that.panelPower) &&
-                Objects.equals(resettableYield, that.resettableYield) &&
-                Objects.equals(yieldToday, that.yieldToday) &&
-                Objects.equals(maxPowerToday, that.maxPowerToday) &&
-                Objects.equals(yieldYesterday, that.yieldYesterday) &&
-                Objects.equals(maxPowerYesterday, that.maxPowerYesterday) &&
-                stateOfOperation == that.stateOfOperation &&
-                trackerOperation == that.trackerOperation &&
-                loadOutputState == that.loadOutputState &&
-                errorCode == that.errorCode &&
-                offReason == that.offReason;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), productType, relayState, firmwareVersion, serialNumber, mainVoltage, mainCurrent, panelVoltage, panelPower, resettableYield, yieldToday, maxPowerToday, yieldYesterday, maxPowerYesterday, stateOfOperation, trackerOperation, loadOutputState, errorCode, offReason);
-    }
-
-    @Override
-    public String toString() {
-        return "VEDirectMessage{" +
-                ", productType=" + productType +
-                ", relayState=" + relayState +
-                ", firmwareVersion=" + firmwareVersion +
-                ", serialNumber='" + serialNumber + '\'' +
-                ", stateOfOperation=" + stateOfOperation +
-                ", trackerOperation=" + trackerOperation +
-                ", loadOutputState=" + loadOutputState +
-                ", errorCode=" + errorCode +
-                ", offReason=" + offReason +
-                '}';
+        return io.freedriver.victron.VEDirectMessage.builder()
+                .timestamp(Instant.ofEpochMilli(getTimestamp()))
+                .productType(getProductType())
+                .relayState(getRelayState())
+                .firmwareVersion(getFirmwareVersion())
+                .serialNumber(getSerialNumber())
+                .mainVoltage(getMainVoltage())
+                .mainCurrent(getMainCurrent())
+                .panelVoltage(getPanelVoltage())
+                .panelPower(getPanelPower())
+                .stateOfOperation(getStateOfOperation())
+                .trackerOperation(getTrackerOperation())
+                .loadOutputState(getLoadOutputState())
+                .errorCode(getErrorCode())
+                .offReason(getOffReason())
+                .resettableYield(getResettableYield())
+                .yieldToday(getYieldToday())
+                .maxPowerToday(getMaxPowerToday())
+                .yieldYesterday(getYieldYesterday())
+                .maxPowerYesterday(getMaxPowerYesterday())
+                .build();
     }
 
     public static int orderByTimestamp(VEDirectMessage veDirectMessage, VEDirectMessage veDirectMessage1) {

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/Event.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/Event.java
@@ -1,18 +1,26 @@
 package io.freedriver.autonomy.jpa.entity.event;
 
-import java.util.Objects;
-
 import io.freedriver.autonomy.jpa.entity.EntityBase;
 import jakarta.persistence.Column;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * An entity that represents either the initial state of some thing or a change
  * in that thing's state.
  */
 @MappedSuperclass
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
 public abstract class Event extends EntityBase {
     public static final long serialVersionUID = -1L;
 
@@ -33,10 +41,6 @@ public abstract class Event extends EntityBase {
     @Column(nullable = true)
     private String eventId;
 
-    protected Event() {
-
-    }
-
     protected Event(long timestamp, GenerationOrigin generationOrigin, String sourceClass, String sourceId, String eventId) {
         super();
         this.timestamp = timestamp;
@@ -44,74 +48,5 @@ public abstract class Event extends EntityBase {
         this.sourceClass = sourceClass;
         this.sourceId = sourceId;
         this.eventId = eventId;
-    }
-
-    public long getTimestamp() {
-        return timestamp;
-    }
-
-    public void setTimestamp(long timestamp) {
-        this.timestamp = timestamp;
-    }
-
-    public GenerationOrigin getGenerationOrigin() {
-        return generationOrigin;
-    }
-
-    public void setGenerationOrigin(GenerationOrigin generationOrigin) {
-        this.generationOrigin = generationOrigin;
-    }
-
-    public String getSourceClass() {
-        return sourceClass;
-    }
-
-    public void setSourceClass(String sourceClass) {
-        this.sourceClass = sourceClass;
-    }
-
-    public String getSourceId() {
-        return sourceId;
-    }
-
-    public void setSourceId(String sourceId) {
-        this.sourceId = sourceId;
-    }
-
-    public String getEventId() {
-        return eventId;
-    }
-
-    public void setEventId(String eventId) {
-        this.eventId = eventId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        Event event = (Event) o;
-        return timestamp == event.timestamp &&
-                generationOrigin == event.generationOrigin &&
-                Objects.equals(sourceClass, event.sourceClass) &&
-                Objects.equals(sourceId, event.sourceId) &&
-                Objects.equals(eventId, event.eventId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), timestamp, generationOrigin, sourceClass, sourceId, eventId);
-    }
-
-    @Override
-    public String toString() {
-        return "Event{" +
-                "timestamp=" + timestamp +
-                ", generationOrigin=" + generationOrigin +
-                ", sourceClass='" + sourceClass + '\'' +
-                ", sourceId='" + sourceId + '\'' +
-                ", eventId='" + eventId + '\'' +
-                '}';
     }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/EventCoordinate.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/EventCoordinate.java
@@ -1,17 +1,25 @@
 package io.freedriver.autonomy.jpa.entity.event;
 
-import java.util.Objects;
-
 import io.freedriver.autonomy.jpa.entity.EmbeddedEntityBase;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * This class seeks to describe where an event came from, both uniquely and nonuniquely.
  */
 @Embeddable
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
 public class EventCoordinate extends EmbeddedEntityBase {
 
     // What initiated this event
@@ -31,56 +39,5 @@ public class EventCoordinate extends EmbeddedEntityBase {
         this.generationOrigin = generationOrigin;
         this.sourceClass = sourceClass;
         this.sourceId = sourceId;
-    }
-
-    public EventCoordinate() {
-    }
-
-    public GenerationOrigin getGenerationOrigin() {
-        return generationOrigin;
-    }
-
-    public void setGenerationOrigin(GenerationOrigin generationOrigin) {
-        this.generationOrigin = generationOrigin;
-    }
-
-    public String getSourceClass() {
-        return sourceClass;
-    }
-
-    public void setSourceClass(String sourceClass) {
-        this.sourceClass = sourceClass;
-    }
-
-    public String getSourceId() {
-        return sourceId;
-    }
-
-    public void setSourceId(String sourceId) {
-        this.sourceId = sourceId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        EventCoordinate that = (EventCoordinate) o;
-        return generationOrigin == that.generationOrigin &&
-                Objects.equals(sourceClass, that.sourceClass) &&
-                Objects.equals(sourceId, that.sourceId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(generationOrigin, sourceClass, sourceId);
-    }
-
-    @Override
-    public String toString() {
-        return "EventCoordinate{" +
-                "generationOrigin=" + generationOrigin +
-                ", sourceClass='" + sourceClass + '\'' +
-                ", sourceId='" + sourceId + '\'' +
-                '}';
     }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/EventDescription.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/EventDescription.java
@@ -1,22 +1,27 @@
 package io.freedriver.autonomy.jpa.entity.event;
 
-import java.util.Objects;
-
 import io.freedriver.autonomy.jpa.entity.EmbeddedEntityBase;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Embeddable
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
 public class EventDescription extends EmbeddedEntityBase {
     @Enumerated(EnumType.STRING)
     private StateType type;
     @Column
     private String state;
-
-    public EventDescription() {
-    }
 
     public EventDescription(StateType type, String state) {
         this.type = type;
@@ -26,43 +31,5 @@ public class EventDescription extends EmbeddedEntityBase {
     public <E extends Enum<E>> EventDescription(StateType type, E enumState) {
         this.type = type;
         this.state = enumState.name();
-    }
-
-    public StateType getType() {
-        return type;
-    }
-
-    public void setType(StateType type) {
-        this.type = type;
-    }
-
-    public String getState() {
-        return state;
-    }
-
-    public void setState(String state) {
-        this.state = state;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        EventDescription that = (EventDescription) o;
-        return type == that.type &&
-                Objects.equals(state, that.state);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, state);
-    }
-
-    @Override
-    public String toString() {
-        return "EventDescription{" +
-                "type=" + type +
-                ", state='" + state + '\'' +
-                '}';
     }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/JoystickEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/JoystickEvent.java
@@ -1,15 +1,29 @@
 package io.freedriver.autonomy.jpa.entity.event.input.joystick;
 
-import java.util.Objects;
-
 import io.freedriver.autonomy.jpa.entity.event.Event;
 import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
 import io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest.JSTestEvent;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table
 @Inheritance(strategy = InheritanceType.JOINED)
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
 public class JoystickEvent extends Event {
     public static final long serialVersionUID = -1L;
 
@@ -24,9 +38,6 @@ public class JoystickEvent extends Event {
 
     @Enumerated(EnumType.STRING)
     private JoystickEventType joystickEventType;
-
-    public JoystickEvent() {
-    }
 
     public JoystickEvent(long timestamp, GenerationOrigin generationOrigin, String sourceClass,
                          String sourceId, String eventId, Long number, Long eventValue, boolean initial,
@@ -52,56 +63,7 @@ public class JoystickEvent extends Event {
         );
     }
 
-    public Long getNumber() {
-        return number;
-    }
-
-    public void setNumber(Long number) {
-        this.number = number;
-    }
-
-    public Long getEventValue() {
-        return eventValue;
-    }
-
-    public void setEventValue(Long eventValue) {
-        this.eventValue = eventValue;
-    }
-
-    public boolean isInitial() {
-        return initial;
-    }
-
-    public void setInitial(boolean initial) {
-        this.initial = initial;
-    }
-
-    public JoystickEventType getJoystickEventType() {
-        return joystickEventType;
-    }
-
-    public void setJoystickEventType(JoystickEventType joystickEventType) {
-        this.joystickEventType = joystickEventType;
-    }
-
     public boolean isButton() {
         return joystickEventType.isButton();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        JoystickEvent that = (JoystickEvent) o;
-        return initial == that.initial &&
-                Objects.equals(number, that.number) &&
-                Objects.equals(eventValue, that.eventValue) &&
-                joystickEventType == that.joystickEventType;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), number, eventValue, initial, joystickEventType);
     }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/jstest/JSMetadata.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/jstest/JSMetadata.java
@@ -2,22 +2,28 @@ package io.freedriver.autonomy.jpa.entity.event.input.joystick.jstest;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiConsumer;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * Metadata container for a joystick device.
  */
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+@NoArgsConstructor
 public class JSMetadata {
     private String title;
     private String hardwareType;
     private String driverVersion;
     private Map<Integer, String> axisNames = new HashMap<>();
     private Map<Integer, String> buttonNames = new HashMap<>();
-
-    public JSMetadata() {
-
-    }
 
     /**
      * Simple method to read metadata strings into a JSMetadata container.
@@ -33,72 +39,6 @@ public class JSMetadata {
         for (int i = 0; i < source.length; i++) {
             putter.accept(i, source[i]);
         }
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getHardwareType() {
-        return hardwareType;
-    }
-
-    public void setHardwareType(String hardwareType) {
-        this.hardwareType = hardwareType;
-    }
-
-    public String getDriverVersion() {
-        return driverVersion;
-    }
-
-    public void setDriverVersion(String driverVersion) {
-        this.driverVersion = driverVersion;
-    }
-
-    public Map<Integer, String> getAxisNames() {
-        return axisNames;
-    }
-
-    public void setAxisNames(Map<Integer, String> axisNames) {
-        this.axisNames = axisNames;
-    }
-
-    public Map<Integer, String> getButtonNames() {
-        return buttonNames;
-    }
-
-    public void setButtonNames(Map<Integer, String> buttonNames) {
-        this.buttonNames = buttonNames;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        JSMetadata that = (JSMetadata) o;
-        return Objects.equals(title, that.title) &&
-                Objects.equals(axisNames, that.axisNames) &&
-                Objects.equals(buttonNames, that.buttonNames);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(title, axisNames, buttonNames);
-    }
-
-    @Override
-    public String toString() {
-        return "JSMetadata{" +
-                "title='" + title + '\'' +
-                ", hardwareType='" + hardwareType + '\'' +
-                ", driverVersion='" + driverVersion + '\'' +
-                ", axisNames=" + axisNames +
-                ", buttonNames=" + buttonNames +
-                '}';
     }
 
     // TODO: HATS

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/jstest/JSTestEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/joystick/jstest/JSTestEvent.java
@@ -7,10 +7,20 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.freedriver.autonomy.jpa.entity.event.StateType;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * Container for Joystick Event Data.
  */
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+@NoArgsConstructor
 public class JSTestEvent {
     private JSMetadata metadata;
     private Instant now;
@@ -18,9 +28,6 @@ public class JSTestEvent {
     private Long time;
     private Long number;
     private Long value;
-
-    public JSTestEvent() {
-    }
 
     public JSTestEvent(JSMetadata metadata, JSTestEventType jsTestEventType, Long time, Long number, Long value) {
         this.metadata = metadata;
@@ -71,54 +78,6 @@ public class JSTestEvent {
                         kvpair -> Long.parseLong(kvpair[1])));
     }
 
-    public JSMetadata getMetadata() {
-        return metadata;
-    }
-
-    public void setMetadata(JSMetadata metadata) {
-        this.metadata = metadata;
-    }
-
-    public Instant getNow() {
-        return now;
-    }
-
-    public void setNow(Instant now) {
-        this.now = now;
-    }
-
-    public JSTestEventType getJsTestEventType() {
-        return jsTestEventType;
-    }
-
-    public void setJsTestEventType(JSTestEventType jsTestEventType) {
-        this.jsTestEventType = jsTestEventType;
-    }
-
-    public Long getTime() {
-        return time;
-    }
-
-    public void setTime(Long time) {
-        this.time = time;
-    }
-
-    public Long getNumber() {
-        return number;
-    }
-
-    public void setNumber(Long number) {
-        this.number = number;
-    }
-
-    public Long getValue() {
-        return value;
-    }
-
-    public void setValue(Long value) {
-        this.value = value;
-    }
-
     public boolean isButton() {
         return Optional.ofNullable(jsTestEventType)
                 .map(JSTestEventType::isButton)
@@ -127,18 +86,6 @@ public class JSTestEvent {
 
     public boolean isAxis() {
         return !isButton();
-    }
-
-    @Override
-    public String toString() {
-        return "JSTestEvent{" +
-                "metadata=" + metadata +
-                ", now=" + now +
-                ", type=" + jsTestEventType +
-                ", time=" + time +
-                ", number=" + number +
-                ", value=" + value +
-                '}';
     }
 
     public String locateSourceId() {

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/DoubleValueSensorEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/DoubleValueSensorEvent.java
@@ -1,7 +1,6 @@
 package io.freedriver.autonomy.jpa.entity.event.input.sensors;
 
 
-import java.util.Objects;
 import java.util.UUID;
 
 import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
@@ -10,16 +9,23 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table
 @Inheritance(strategy = InheritanceType.JOINED)
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
 public class DoubleValueSensorEvent extends SensorEvent {
     @Column(name = "event_value")
     private double eventValue;
-
-    public DoubleValueSensorEvent() {
-    }
 
     public DoubleValueSensorEvent(UUID boardId, String sensorName, double eventValue) {
         super(boardId, sensorName);
@@ -29,34 +35,5 @@ public class DoubleValueSensorEvent extends SensorEvent {
     public DoubleValueSensorEvent(long timestamp, GenerationOrigin generationOrigin, String sourceClass, String sourceId, String eventId, UUID boardId, String sensorName, double eventValue) {
         super(timestamp, generationOrigin, sourceClass, sourceId, eventId, boardId, sensorName);
         this.eventValue = eventValue;
-    }
-
-    public double getEventValue() {
-        return eventValue;
-    }
-
-    public void setEventValue(double eventValue) {
-        this.eventValue = eventValue;
-    }
-
-    @Override
-    public String toString() {
-        return "FloatValueSensorEvent{" +
-                "eventValue=" + eventValue +
-                '}';
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        DoubleValueSensorEvent that = (DoubleValueSensorEvent) o;
-        return Double.compare(that.eventValue, eventValue) == 0;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), eventValue);
     }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/SensorEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/input/sensors/SensorEvent.java
@@ -1,23 +1,29 @@
 package io.freedriver.autonomy.jpa.entity.event.input.sensors;
 
-import java.util.Objects;
 import java.util.UUID;
 
 import io.freedriver.autonomy.jpa.entity.event.Event;
 import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @MappedSuperclass
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
 public abstract class SensorEvent extends Event {
     @Column
     private UUID boardId;
 
     @Column
     private String sensorName;
-
-    public SensorEvent() {
-    }
 
     public SensorEvent(UUID boardId, String sensorName) {
         this.boardId = boardId;
@@ -28,35 +34,5 @@ public abstract class SensorEvent extends Event {
         super(timestamp, generationOrigin, sourceClass, sourceId, eventId);
         this.boardId = boardId;
         this.sensorName = sensorName;
-    }
-
-    public UUID getBoardId() {
-        return boardId;
-    }
-
-    public void setBoardId(UUID boardId) {
-        this.boardId = boardId;
-    }
-
-    public String getSensorName() {
-        return sensorName;
-    }
-
-    public void setSensorName(String sensorName) {
-        this.sensorName = sensorName;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        SensorEvent that = (SensorEvent) o;
-        return Objects.equals(boardId, that.boardId) && Objects.equals(sensorName, that.sensorName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), boardId, sensorName);
     }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/GPSEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/GPSEvent.java
@@ -5,11 +5,25 @@ import java.time.Instant;
 
 import io.freedriver.autonomy.jpa.entity.event.Event;
 import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Table
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
 public class GPSEvent extends Event {
     private static final String GPS_SOURCE = "GPS_LOCATION";
 
@@ -18,10 +32,6 @@ public class GPSEvent extends Event {
 
     @Column
     private BigDecimal longitude;
-
-    public GPSEvent() {
-    }
-
 
     public GPSEvent(long timestamp, GenerationOrigin generationOrigin, String sourceClass, String sourceId, String eventId, BigDecimal latitude, BigDecimal longitude) {
         super(timestamp, generationOrigin, sourceClass, sourceId, eventId);
@@ -38,21 +48,5 @@ public class GPSEvent extends Event {
                 null,
                 latitude, longitude
         );
-    }
-
-    public BigDecimal getLatitude() {
-        return latitude;
-    }
-
-    public void setLatitude(BigDecimal latitude) {
-        this.latitude = latitude;
-    }
-
-    public BigDecimal getLongitude() {
-        return longitude;
-    }
-
-    public void setLongitude(BigDecimal longitude) {
-        this.longitude = longitude;
     }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/TemperatureEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/TemperatureEvent.java
@@ -1,55 +1,31 @@
 package io.freedriver.autonomy.jpa.entity.event.sensor;
 
-import java.util.Objects;
-
 import io.freedriver.autonomy.jpa.entity.event.Event;
 import io.freedriver.autonomy.jpa.entity.event.GenerationOrigin;
 import io.freedriver.math.measurement.types.thermo.Temperature;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Table
 @Entity
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
 public class TemperatureEvent extends Event {
 
     @Column
     private Temperature temperature;
 
-    public TemperatureEvent() {
-    }
-
     public TemperatureEvent(long timestamp, GenerationOrigin generationOrigin, String sourceClass, String sourceId, String eventId, Temperature temperature) {
         super(timestamp, generationOrigin, sourceClass, sourceId, eventId);
         this.temperature = temperature;
-    }
-
-    public Temperature getTemperature() {
-        return temperature;
-    }
-
-    public void setTemperature(Temperature temperature) {
-        this.temperature = temperature;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        TemperatureEvent that = (TemperatureEvent) o;
-        return Objects.equals(temperature, that.temperature);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), temperature);
-    }
-
-    @Override
-    public String toString() {
-        return "TemperatureEvent{" +
-                "temperature=" + temperature +
-                '}';
     }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/TemperatureValue.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/sensor/TemperatureValue.java
@@ -5,38 +5,28 @@ import static io.freedriver.autonomy.jpa.entity.event.sensor.TemperatureUnit.KEL
 import java.math.BigDecimal;
 import java.util.Objects;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
 public class TemperatureValue implements Comparable<TemperatureValue> {
     private static final BigDecimal EQUIVALENCE = new BigDecimal("0.000000000001");
 
     private BigDecimal value;
     private TemperatureUnit unit;
 
-    public TemperatureValue(BigDecimal value, TemperatureUnit unit) {
-        this.value = value;
-        this.unit = unit;
-    }
-
     public TemperatureValue to(TemperatureUnit newUnit) {
         return new TemperatureValue(
                 newUnit.convert(value, unit),
                 newUnit
         );
-    }
-
-    public BigDecimal getValue() {
-        return value;
-    }
-
-    public void setValue(BigDecimal value) {
-        this.value = value;
-    }
-
-    public TemperatureUnit getUnit() {
-        return unit;
-    }
-
-    public void setUnit(TemperatureUnit unit) {
-        this.unit = unit;
     }
 
     public TemperatureValue convert(TemperatureUnit unit) {

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/speech/SpeechEvent.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/event/speech/SpeechEvent.java
@@ -1,17 +1,25 @@
 package io.freedriver.autonomy.jpa.entity.event.speech;
 
-import java.util.Objects;
-
 import io.freedriver.autonomy.jpa.entity.event.Event;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table
 @Inheritance(strategy = InheritanceType.JOINED)
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
 public class SpeechEvent extends Event {
 
     @Column
@@ -22,45 +30,4 @@ public class SpeechEvent extends Event {
 
     @Column
     private String text;
-
-    public SpeechEvent() {
-    }
-
-    public SpeechEventType getSpeechEventType() {
-        return speechEventType;
-    }
-
-    public void setSpeechEventType(SpeechEventType speechEventType) {
-        this.speechEventType = speechEventType;
-    }
-
-    public String getSubject() {
-        return subject;
-    }
-
-    public void setSubject(String subject) {
-        this.subject = subject;
-    }
-
-    public String getText() {
-        return text;
-    }
-
-    public void setText(String text) {
-        this.text = text;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        // if (!super.equals(o)) return false;
-        SpeechEvent that = (SpeechEvent) o;
-        return Objects.equals(text, that.text);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(text);
-    }
 }

--- a/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/StateOfChargeConfig.java
+++ b/jpa/src/main/java/io/freedriver/autonomy/jpa/entity/math/StateOfChargeConfig.java
@@ -9,32 +9,23 @@ import java.util.stream.Collectors;
 
 import io.freedriver.math.measurement.types.electrical.Potential;
 import io.freedriver.math.number.ScaledNumber;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 // 3.2 -> 4.2
 // 19.2 -> 25.2
 
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+@NoArgsConstructor
 public class StateOfChargeConfig {
     private int cells = 12;
     private Map<BigDecimal, BigDecimal> voltages = Chemistries.CHEM_18650.getVoltageMap();
-
-    public StateOfChargeConfig() {
-    }
-
-    public int getCells() {
-        return cells;
-    }
-
-    public void setCells(int cells) {
-        this.cells = cells;
-    }
-
-    public Map<BigDecimal, BigDecimal> getVoltages() {
-        return voltages;
-    }
-
-    public void setVoltages(Map<BigDecimal, BigDecimal> voltages) {
-        this.voltages = voltages;
-    }
 
     public BigDecimal calculate(Potential voltage) {
         return SocRange.of(voltages.entrySet()

--- a/quarkus/src/main/java/io/freedriver/autonomy/async/VEDirectHistoricalOperations.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/async/VEDirectHistoricalOperations.java
@@ -19,7 +19,7 @@ public enum VEDirectHistoricalOperations {
     // Find the beginning of the day.
     /*
     public static Instant beginningOfDay(List<VEDirectMessage> history, OffReason example) {
-        Optional<MarkedTimeFrame<OffReason>> thisMorning = TimeFrame.blocks(history.stream(), VEDirectMessage::getTimestamp, VEDirectMessage::getOffReason)
+        Optional<MarkedTimeFrame<OffReason>> thisMorning = TimeFrame.blocks(history.stream(), VEDirectMessage::timestamp, VEDirectMessage::offReason)
                 .stream()
                 // Between 12AM and 12PM
                 .filter(block -> block.getStart().isAfter(LocalDate.now().atStartOfDay(UTC).toInstant()))
@@ -33,9 +33,9 @@ public enum VEDirectHistoricalOperations {
 
 
         Optional<Instant> lastTimeOff = history.stream()
-                .filter(message -> message.getOffReason() == OffReason.NO_INPUT_POWER)
-                .max(Comparator.comparing(VEDirectMessage::getTimestamp))
-                .map(VEDirectMessage::getTimestamp);
+                .filter(message -> message.offReason() == OffReason.NO_INPUT_POWER)
+                .max(Comparator.comparing(VEDirectMessage::timestamp))
+                .map(VEDirectMessage::timestamp);
 
 
 

--- a/quarkus/src/main/java/io/freedriver/autonomy/cache/CacheKey.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/cache/CacheKey.java
@@ -1,35 +1,7 @@
 package io.freedriver.autonomy.cache;
 
-import java.util.Objects;
+import lombok.Builder;
 
-public class CacheKey<E, T> {
-    private final E base;
-    private final Class<T> klazz;
-
-    public CacheKey(E base, Class<T> klazz) {
-        this.base = base;
-        this.klazz = klazz;
-    }
-
-    public E getBase() {
-        return base;
-    }
-
-    public Class<T> getKlazz() {
-        return klazz;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CacheKey<?, ?> cacheKey = (CacheKey<?, ?>) o;
-        return Objects.equals(base, cacheKey.base) &&
-                Objects.equals(klazz, cacheKey.klazz);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(base, klazz);
-    }
+@Builder(toBuilder = true)
+public record CacheKey<E, T>(E base, Class<T> klazz) {
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/jsonlink/SimpleAliasHandler.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/jsonlink/SimpleAliasHandler.java
@@ -59,11 +59,11 @@ public class SimpleAliasHandler implements SimpleAliasApi {
     @Override
     public AliasView setGroup(UUID boardId, String group, boolean desiredState) throws IOException {
         connectorService.writeDigital(boardId, simpleAliasService.getMapping(boardId)
-                .getAppliances()
+                .appliances()
                 .stream()
-                .filter(appliance -> appliance.getGroups().contains(group))
+                .filter(appliance -> appliance.groups().contains(group))
                 .collect(Collectors.toMap(
-                        Appliance::getIdentifier,
+                        Appliance::identifier,
                         app -> desiredState,
                         (a, b) -> b
                 )));

--- a/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/vedirect/VEDirectEndpoint.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/jaxrs/endpoint/vedirect/VEDirectEndpoint.java
@@ -78,6 +78,6 @@ public class VEDirectEndpoint implements VEDirectApi {
 
     private Stream<VictronDevice> bySerial(String serial) {
         return getDevices().stream()
-                .filter(device -> Objects.equals(serial, device.getSerialNumber()));
+                .filter(device -> Objects.equals(serial, device.serialNumber()));
     }
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/BoardAnalogHistory.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/BoardAnalogHistory.java
@@ -4,33 +4,21 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
+import lombok.Builder;
 
-public class BoardAnalogHistory {
-    private Map<Identifier, Integer> minimums = new LinkedHashMap<>();
-    private Map<Identifier, Integer> maximums = new LinkedHashMap<>();
-    private Map<Identifier, Integer> lastKnowns = new LinkedHashMap<>();
+@Builder(toBuilder = true)
+public record BoardAnalogHistory(
+        Map<Identifier, Integer> minimums,
+        Map<Identifier, Integer> maximums,
+        Map<Identifier, Integer> lastKnowns) {
 
-    public Map<Identifier, Integer> getMinimums() {
-        return minimums;
+    public BoardAnalogHistory {
+        minimums = minimums == null ? new LinkedHashMap<>() : minimums;
+        maximums = maximums == null ? new LinkedHashMap<>() : maximums;
+        lastKnowns = lastKnowns == null ? new LinkedHashMap<>() : lastKnowns;
     }
 
-    public void setMinimums(Map<Identifier, Integer> minimums) {
-        this.minimums = minimums;
-    }
-
-    public Map<Identifier, Integer> getMaximums() {
-        return maximums;
-    }
-
-    public void setMaximums(Map<Identifier, Integer> maximums) {
-        this.maximums = maximums;
-    }
-
-    public Map<Identifier, Integer> getLastKnowns() {
-        return lastKnowns;
-    }
-
-    public void setLastKnowns(Map<Identifier, Integer> lastKnowns) {
-        this.lastKnowns = lastKnowns;
+    public BoardAnalogHistory() {
+        this(new LinkedHashMap<>(), new LinkedHashMap<>(), new LinkedHashMap<>());
     }
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorService.java
@@ -45,22 +45,24 @@ public class ConnectorService extends ConnectorServiceCommon {
     @Deprecated
     public synchronized Map<Identifier, Boolean> readDigital(UUID boardId, Collection<Identifier> pins) {
         return send(boardId, pins.stream()
-                .reduce(new Request(), Request::digitalRead, (a, b) -> a))
-                .getDigital();
+                .reduce(Request.empty(), Request::digitalRead, (a, b) -> a))
+                .digital();
     }
 
      */
 
     public synchronized Response readDigitalAndAnalog(UUID boardId, Collection<Identifier> pins, Stream<AnalogRead> analogReads) {
         return send(boardId, pins.stream()
-                .reduce(new Request(), Request::digitalRead, (a, b) -> a)
+                .reduce(Request.empty(), Request::digitalRead, (a, b) -> a)
                 .analogRead(analogReads));
     }
 
     public synchronized Map<Identifier, Boolean> writeDigital(UUID boardId, Map<Identifier, Boolean> state) {
-        Request request = new Request();
-        state.forEach((pin, pinState) -> request.digitalWrite(new DigitalWrite(pin, pinState)));
+        Request request = state.entrySet().stream()
+                .reduce(Request.empty(),
+                        (req, e) -> req.digitalWrite(new DigitalWrite(e.getKey(), e.getValue())),
+                        (a, b) -> a);
         return send(boardId, request)
-                .getDigital();
+                .digital();
     }
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorServiceCommon.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorServiceCommon.java
@@ -103,21 +103,23 @@ public class ConnectorServiceCommon {
     @Deprecated
     public synchronized Map<Identifier, Boolean> readDigital(UUID boardId, Collection<Identifier> pins) {
         return send(boardId, pins.stream()
-                .reduce(new Request(), Request::digitalRead, (a, b) -> a))
-                .getDigital();
+                .reduce(Request.empty(), Request::digitalRead, (a, b) -> a))
+                .digital();
     }
 
     public synchronized Response readDigitalAndAnalog(UUID boardId, Collection<Identifier> pins, Stream<AnalogRead> analogReads) {
         return send(boardId, pins.stream()
-                .reduce(new Request(), Request::digitalRead, (a, b) -> a)
+                .reduce(Request.empty(), Request::digitalRead, (a, b) -> a)
                 .analogRead(analogReads));
     }
 
     public synchronized Map<Identifier, Boolean> writeDigital(UUID boardId, Map<Identifier, Boolean> state) {
-        Request request = new Request();
-        state.forEach((pin, pinState) -> request.digitalWrite(new DigitalWrite(pin, pinState)));
+        Request request = state.entrySet().stream()
+                .reduce(Request.empty(),
+                        (req, e) -> req.digitalWrite(new DigitalWrite(e.getKey(), e.getValue())),
+                        (a, b) -> a);
         return send(boardId, request)
-                .getDigital();
+                .digital();
     }
 
      */

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/PinCoordinate.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/PinCoordinate.java
@@ -1,38 +1,10 @@
 package io.freedriver.autonomy.service;
 
-import java.util.Objects;
 import java.util.UUID;
 
 import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
+import lombok.Builder;
 
-public class PinCoordinate {
-    private final UUID boardId;
-    private final Identifier identifier;
-
-    public PinCoordinate(UUID boardId, Identifier identifier) {
-        this.boardId = boardId;
-        this.identifier = identifier;
-    }
-
-    public UUID getBoardId() {
-        return boardId;
-    }
-
-    public Identifier getIdentifier() {
-        return identifier;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        PinCoordinate that = (PinCoordinate) o;
-        return Objects.equals(boardId, that.boardId) &&
-                Objects.equals(identifier, that.identifier);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(boardId, identifier);
-    }
+@Builder(toBuilder = true)
+public record PinCoordinate(UUID boardId, Identifier identifier) {
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/SensorHistory.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/SensorHistory.java
@@ -4,14 +4,15 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class SensorHistory {
-    private Map<UUID, BoardAnalogHistory> history = new LinkedHashMap<>();
+import lombok.Builder;
 
-    public Map<UUID, BoardAnalogHistory> getHistory() {
-        return history;
+@Builder(toBuilder = true)
+public record SensorHistory(Map<UUID, BoardAnalogHistory> history) {
+    public SensorHistory {
+        history = history == null ? new LinkedHashMap<>() : history;
     }
 
-    public void setHistory(Map<UUID, BoardAnalogHistory> history) {
-        this.history = history;
+    public SensorHistory() {
+        this(new LinkedHashMap<>());
     }
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/SensorValues.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/SensorValues.java
@@ -4,73 +4,41 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
 
-public class SensorValues {
-    private Instant recordedOn = Instant.now();
-    private int min = -1;
-    private int raw = -1;
-    private int max = -1;
-    private double percentage = -1;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record SensorValues(
+        Instant recordedOn,
+        int min,
+        int raw,
+        int max,
+        double percentage) {
+
+    public SensorValues {
+        if (recordedOn == null) {
+            recordedOn = Instant.now();
+        }
+    }
 
     public SensorValues() {
+        this(Instant.now(), -1, -1, -1, -1);
     }
-
-    public Instant getRecordedOn() {
-        return recordedOn;
-    }
-
-    public void setRecordedOn(Instant recordedOn) {
-        this.recordedOn = recordedOn;
-    }
-
-    public int getMin() {
-        return min;
-    }
-
-    public void setMin(int min) {
-        this.min = min;
-    }
-
-    public int getRaw() {
-        return raw;
-    }
-
-    public void setRaw(int raw) {
-        this.raw = raw;
-    }
-
-    public int getMax() {
-        return max;
-    }
-
-    public void setMax(int max) {
-        this.max = max;
-    }
-
-    public double getPercentage() {
-        return percentage;
-    }
-
-    public void setPercentage(double percentage) {
-        this.percentage = percentage;
-    }
-    // 267 : 260, 1000
-    // 267 : 0, 267
-    // 267 :
 
     public SensorValues apply(int value) {
-        if (value > max || max == -1) {
-            max = value;
-        }
-        if (value < min || min == -1) {
-            min = value;
-        }
-        raw = value;
-        if (min != -1 && max != -1 && value != -1 && (max - min) > 0) {
-            percentage = BigDecimal.valueOf(((double)value - (double)min) / ((double)max - (double)min))
+        int nextMax = (value > max || max == -1) ? value : max;
+        int nextMin = (value < min || min == -1) ? value : min;
+        double nextPercentage = percentage;
+        if (nextMin != -1 && nextMax != -1 && value != -1 && (nextMax - nextMin) > 0) {
+            nextPercentage = BigDecimal.valueOf(((double) value - (double) nextMin) / ((double) nextMax - (double) nextMin))
                     .multiply(BigDecimal.valueOf(100))
                     .setScale(2, RoundingMode.HALF_UP)
                     .doubleValue();
         }
-        return this;
+        return toBuilder()
+                .min(nextMin)
+                .raw(value)
+                .max(nextMax)
+                .percentage(nextPercentage)
+                .build();
     }
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
@@ -90,12 +90,12 @@ public class SimpleAliasService  {
 
     public void populateSensorCacheFromHistory() {
         SensorHistory sensorHistory = readSensorHistory();
-        sensorHistory.getHistory()
+        sensorHistory.history()
                 .forEach(this::populateBoardHistory);
     }
 
     public void populateBoardHistory(UUID boardId, BoardAnalogHistory boardAnalogHistory) {
-        Stream.concat(boardAnalogHistory.getMaximums().keySet().stream(), boardAnalogHistory.getMinimums().keySet().stream())
+        Stream.concat(boardAnalogHistory.maximums().keySet().stream(), boardAnalogHistory.minimums().keySet().stream())
                 .collect(Collectors.toSet())
                 .stream()
                 .map(identifier -> new PinCoordinate(boardId, identifier))
@@ -104,14 +104,14 @@ public class SimpleAliasService  {
 
     private void populatePinHistory(PinCoordinate coordinate, BoardAnalogHistory boardAnalogHistory) {
         SensorValues sensorValues = new SensorValues();
-        if (boardAnalogHistory.getMinimums().containsKey(coordinate.getIdentifier())) {
-            sensorValues.setMin(boardAnalogHistory.getMinimums().get(coordinate.getIdentifier()));
+        if (boardAnalogHistory.minimums().containsKey(coordinate.identifier())) {
+            sensorValues = sensorValues.toBuilder().min(boardAnalogHistory.minimums().get(coordinate.identifier())).build();
         }
-        if (boardAnalogHistory.getMaximums().containsKey(coordinate.getIdentifier())) {
-            sensorValues.setMax(boardAnalogHistory.getMaximums().get(coordinate.getIdentifier()));
+        if (boardAnalogHistory.maximums().containsKey(coordinate.identifier())) {
+            sensorValues = sensorValues.toBuilder().max(boardAnalogHistory.maximums().get(coordinate.identifier())).build();
         }
-        if (boardAnalogHistory.getLastKnowns().containsKey(coordinate.getIdentifier())) {
-            sensorValues.setRaw(boardAnalogHistory.getLastKnowns().get(coordinate.getIdentifier()));
+        if (boardAnalogHistory.lastKnowns().containsKey(coordinate.identifier())) {
+            sensorValues = sensorValues.toBuilder().raw(boardAnalogHistory.lastKnowns().get(coordinate.identifier())).build();
         }
         sensorCache.put(coordinate, sensorValues);
     }
@@ -138,9 +138,9 @@ public class SimpleAliasService  {
     public Future<Boolean> cacheAnalogPins(Mapping mapping) {
         return pool.submit(() -> {
             try {
-                Request readAnalogPinsAnyway = new Request()
-                        .analogRead(mapping.getAnalogSensors().stream().map(AnalogSensor::asAnalogRead));
-                Response response = connectorService.send(mapping.getConnectorId(), readAnalogPinsAnyway);
+                Request readAnalogPinsAnyway = Request.empty()
+                        .analogRead(mapping.analogSensors().stream().map(AnalogSensor::asAnalogRead));
+                Response response = connectorService.send(mapping.connectorId(), readAnalogPinsAnyway);
                 cacheBoardState(mapping, response);
                 sendAnalogSensorEvents(mapping, response);
                 return true;
@@ -156,11 +156,11 @@ public class SimpleAliasService  {
      */
     public Map<Identifier, Boolean> identifiers(UUID boardId, Map<String, Boolean> desiredState) throws IOException {
         Map<String, Identifier> namedPins = getMapping(boardId)
-                .getAppliances()
+                .appliances()
                 .stream()
                 .collect(Collectors.toMap(
-                        Appliance::getName,
-                        Appliance::getIdentifier,
+                        Appliance::name,
+                        Appliance::identifier,
                         (a, b) -> b
                 ));
 
@@ -177,7 +177,7 @@ public class SimpleAliasService  {
         return getMappings()
                 .getMappings()
                 .stream()
-                .filter(mapping -> Objects.equals(boardId, mapping.getConnectorId()))
+                .filter(mapping -> Objects.equals(boardId, mapping.connectorId()))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Unable to find mapping for board " + boardId));
     }
@@ -194,24 +194,24 @@ public class SimpleAliasService  {
     }
 
     public Map<Identifier, Boolean> currentState(UUID boardId, Mapping mapping) {
-        Map<Identifier, Boolean> digitalStateFromCache = mapping.getAppliances().stream()
-                .map(appliance -> new PinCoordinate(boardId, appliance.getIdentifier()))
+        Map<Identifier, Boolean> digitalStateFromCache = mapping.appliances().stream()
+                .map(appliance -> new PinCoordinate(boardId, appliance.identifier()))
                 .filter(pinCoordinate -> digitalPinCache.containsKey(pinCoordinate))
                 .collect(Collectors.toMap(
-                        PinCoordinate::getIdentifier,
+                        PinCoordinate::identifier,
                         digitalPinCache::get,
                         (a, b) -> b
                 ));
-        if (digitalStateFromCache.keySet().containsAll(mapping.getAppliances().stream().map(Appliance::getIdentifier)
+        if (digitalStateFromCache.keySet().containsAll(mapping.appliances().stream().map(Appliance::identifier)
                 .collect(Collectors.toSet()))) {
             return digitalStateFromCache;
         }
         return cacheBoardState(mapping, connectorService
                 .readDigitalAndAnalog(
                         boardId,
-                        mapping.getAppliances().stream().map(Appliance::getIdentifier).collect(Collectors.toSet()),
-                        mapping.getAnalogSensors().stream().map(AnalogSensor::asAnalogRead))
-        ).getDigital();
+                        mapping.appliances().stream().map(Appliance::identifier).collect(Collectors.toSet()),
+                        mapping.analogSensors().stream().map(AnalogSensor::asAnalogRead))
+        ).digital();
     }
 
     public Map<Identifier, Boolean> cacheBoardDigitalState(UUID boardId, Map<Identifier, Boolean> digitalState) {
@@ -221,36 +221,36 @@ public class SimpleAliasService  {
 
     public Response cacheBoardState(Mapping mapping, Response currentState) {
         // Cache Digital Pins
-        currentState.getDigital().forEach((k, v) ->
-                digitalPinCache.put(new PinCoordinate(mapping.getConnectorId(), k), v));
+        currentState.digital().forEach((k, v) ->
+                digitalPinCache.put(new PinCoordinate(mapping.connectorId(), k), v));
 
         /*
         // Cache Analog Pins
-        currentState.getAnalog()
-                .forEach(analogResponse -> applyAnalogCache(mapping.getConnectorId(), analogResponse));
+        currentState.analog()
+                .forEach(analogResponse -> applyAnalogCache(mapping.connectorId(), analogResponse));
 
         persistAnalogCache();
 
-        Map<String, Double> percentages = mapping.getAnalogSensors()
+        Map<String, Double> percentages = mapping.analogSensors()
             .stream()
             .filter(analogSensor -> sensorCache.keySet()
                 .stream()
-                .anyMatch(coordinate -> Objects.equals(coordinate, new PinCoordinate(mapping.getConnectorId(), analogSensor.getPin()))))
+                .anyMatch(coordinate -> Objects.equals(coordinate, new PinCoordinate(mapping.connectorId(), analogSensor.pin()))))
             .collect(Collectors.toMap(
-                    AnalogSensor::getName,
-                    as -> averageSensorMetrics(as, sensorCache.get(new PinCoordinate(mapping.getConnectorId(), as.getPin()))).getPercentage(),
+                    AnalogSensor::name,
+                    as -> averageSensorMetrics(as, sensorCache.get(new PinCoordinate(mapping.connectorId(), as.pin()))).percentage(),
                     (a, b) -> b
             ));
 
         // Fire Alert events as needed
-        mapping.getAnalogAlerts()
+        mapping.analogAlerts()
                 .forEach(analogAlert -> {
-                    if (percentages.keySet().containsAll(analogAlert.getSensors())) {
-                        if (analogAlert.getMatching().test(
-                                analogAlert.getValue(),
-                                analogAlert.getCondition(),
+                    if (percentages.keySet().containsAll(analogAlert.sensors())) {
+                        if (analogAlert.matching().test(
+                                analogAlert.value(),
+                                analogAlert.condition(),
                                 percentages.entrySet().stream()
-                                    .filter(e -> analogAlert.getSensors().stream()
+                                    .filter(e -> analogAlert.sensors().stream()
                                         .anyMatch(name -> Objects.equals(name, e.getKey())))
                                         .map(Map.Entry::getValue))) {
                             speak(analogAlert, percentages);
@@ -272,35 +272,35 @@ public class SimpleAliasService  {
                 .map(e -> e.getKey() + ": " + e.getValue())
                 .collect(Collectors.joining("\n")));
         SpeechEvent speechEvent = new SpeechEvent();
-        speechEvent.setSourceId("sensors://"+String.join(",", analogAlert.getSensors()));
+        speechEvent.setSourceId("sensors://"+String.join(",", analogAlert.sensors()));
         speechEvent.setSourceClass(getClass().getName());
-        speechEvent.setSubject(String.join("/", analogAlert.getSensors()));
+        speechEvent.setSubject(String.join("/", analogAlert.sensors()));
         speechEvent.setSpeechEventType(SpeechEventType.INFO);
-        speechEvent.setText(analogAlert.getContent());
+        speechEvent.setText(analogAlert.content());
         speech.fire(speechEvent);
     }
 
     private void sendAnalogSensorEvents(Mapping mapping, Response currentState) {
-        currentState.getAnalog()
+        currentState.analog()
                 .forEach(analogResponse -> getAnalogSensorByMapping(mapping, analogResponse)
                     .ifPresent(analogSensor -> {
                         DoubleValueSensorEvent event = new DoubleValueSensorEvent();
-                        event.setBoardId(mapping.getConnectorId());
-                        event.setSensorName(mapping.getConnectorId() + "/" +analogSensor.getName()+"/live");
+                        event.setBoardId(mapping.connectorId());
+                        event.setSensorName(mapping.connectorId() + "/" +analogSensor.name()+"/live");
                         event.setGenerationOrigin(GenerationOrigin.NON_HUMAN);
-                        event.setSourceId(mapping.getConnectorId().toString());
+                        event.setSourceId(mapping.connectorId().toString());
                         event.setSourceClass(getClass().getName());
-                        event.setSourceId(mapping.getConnectorId().toString());
-                        event.setEventId("analog/"+analogSensor.getPin().getPin());
-                        event.setEventValue(analogResponse.getRaw());
+                        event.setSourceId(mapping.connectorId().toString());
+                        event.setEventId("analog/"+analogSensor.pin().pin());
+                        event.setEventValue(analogResponse.raw());
                         floatValueSensorService.save(event);
                 }));
     }
 
     private Optional<AnalogSensor> getAnalogSensorByMapping(Mapping mapping, AnalogResponse analogResponse) {
-        return mapping.getAnalogSensors()
+        return mapping.analogSensors()
                 .stream()
-                .filter(analogSensor -> Objects.equals(analogSensor.getPin(), analogResponse.getPin()))
+                .filter(analogSensor -> Objects.equals(analogSensor.pin(), analogResponse.pin()))
                 .findFirst();
     }
 
@@ -331,71 +331,70 @@ public class SimpleAliasService  {
         SensorHistory sensorHistory = readSensorHistory();
         sensorCache
                 .forEach((key, value) -> {
-                    if (!sensorHistory.getHistory().containsKey(key.getBoardId())) {
-                        sensorHistory.getHistory().put(key.getBoardId(), new BoardAnalogHistory());
+                    if (!sensorHistory.history().containsKey(key.boardId())) {
+                        sensorHistory.history().put(key.boardId(), new BoardAnalogHistory());
                     }
-                    BoardAnalogHistory boardHistory = sensorHistory.getHistory().get(key.getBoardId());
-                    boardHistory.getMinimums()
-                            .put(key.getIdentifier(), value.getMin());
-                    boardHistory.getMaximums()
-                            .put(key.getIdentifier(), value.getMax());
-                    boardHistory.getLastKnowns()
-                            .put(key.getIdentifier(), value.getRaw());
+                    BoardAnalogHistory boardHistory = sensorHistory.history().get(key.boardId());
+                    boardHistory.minimums()
+                            .put(key.identifier(), value.min());
+                    boardHistory.maximums()
+                            .put(key.identifier(), value.max());
+                    boardHistory.lastKnowns()
+                            .put(key.identifier(), value.raw());
                 });
 
         writeSensorHistory(sensorHistory);
     }
 
     private void applyAnalogCache(UUID boardId, AnalogResponse analogResponse) {
-        PinCoordinate coordinate = new PinCoordinate(boardId, analogResponse.getPin());
+        PinCoordinate coordinate = new PinCoordinate(boardId, analogResponse.pin());
         SensorValues values = new SensorValues();
         if (sensorCache.containsKey(coordinate)) {
             values = sensorCache.get(coordinate);
         }
-        values.apply(analogResponse.getRaw());
+        values = values.apply(analogResponse.raw());
         sensorCache.remove(coordinate);
         sensorCache.put(coordinate, values);
     }
 
     public AliasView makeView(UUID boardId) throws IOException {
         Mapping mapping = getMapping(boardId);
-        AliasView aliasView = new AliasView();
 
         Map<Identifier, Boolean> digitalState = currentState(boardId, mapping);
-        aliasView.setApplianceStates(mapping.getAppliances()
+        Map<String, Boolean> applianceStates = mapping.appliances()
                 .stream()
-                .filter(appliance -> digitalState.containsKey(appliance.getIdentifier()))
+                .filter(appliance -> digitalState.containsKey(appliance.identifier()))
                 .collect(Collectors.toMap(
-                        Appliance::getName,
-                        appliance -> digitalState.get(appliance.getIdentifier()),
+                        Appliance::name,
+                        appliance -> digitalState.get(appliance.identifier()),
                         (a, b) -> a
-                )));
+                ));
 
-        Map<String, Set<Boolean>> grouped = mapping.getAppliances()
+        Map<String, Set<Boolean>> grouped = mapping.appliances()
                 .stream()
                 .reduce(new HashMap<>(),
                         (hm, app) -> {
-                            app.getGroups()
+                            app.groups()
                                     .forEach(group -> {
                                         if (!hm.containsKey(group)) {
                                             hm.put(group, new HashSet<>());
                                         }
-                                        hm.get(group).add(digitalState.get(app.getIdentifier()));
+                                        hm.get(group).add(digitalState.get(app.identifier()));
                                     });
                             return hm;
                         },
                         (a, b) -> a);
 
-        aliasView.setGroupStates(grouped.entrySet()
+        Map<String, Boolean> groupStates = grouped.entrySet()
                 .stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
                         e -> !e.getValue().contains(false)
-                )));
+                ));
 
         /*
         sensorCache.entrySet().stream()
-                .filter(e -> Objects.equals(boardId, e.getKey().getBoardId()))
+                .filter(e -> Objects.equals(boardId, e.getKey().boardId()))
                 .forEach(e -> getAnalogSensorByPin(mapping, e.getKey())
                         .ifPresent(analogSensor -> {
                             applySensorMetrics(aliasView, analogSensor, averageSensorMetrics(analogSensor, e.getValue()));
@@ -403,63 +402,65 @@ public class SimpleAliasService  {
 
          */
 
-        return aliasView;
+        return AliasView.builder()
+                .applianceStates(applianceStates)
+                .groupStates(groupStates)
+                .build();
     }
 
 
     private synchronized SensorValues averageSensorMetrics(AnalogSensor analogSensor, SensorValues sensorValues) {
-        if (analogSensor.getAverageOver() < 0) {
+        if (analogSensor.averageOver() < 0) {
             return sensorValues;
         }
         if (!sensorAverages.containsKey(analogSensor)) {
             sensorAverages.put(analogSensor, new ArrayList<>());
         } else {
-            Instant expiresOn = Instant.now().plus(Duration.ofMillis(analogSensor.getAverageOver()));
+            Instant expiresOn = Instant.now().plus(Duration.ofMillis(analogSensor.averageOver()));
             sensorAverages.get(analogSensor)
-                    .removeIf(historical -> historical.getRecordedOn().isAfter(expiresOn));
+                    .removeIf(historical -> historical.recordedOn().isAfter(expiresOn));
         }
         sensorAverages.get(analogSensor)
                 .add(sensorValues);
 
-        SensorValues averagedForTime = new SensorValues();
-
-        averagedForTime.setRecordedOn(sensorValues.getRecordedOn());
         SensorValues latest = sensorAverages.get(analogSensor)
                 .stream()
-                .max(Comparator.comparing(SensorValues::getRecordedOn))
+                .max(Comparator.comparing(SensorValues::recordedOn))
                 .orElse(sensorValues);
 
         int average = Double.valueOf(sensorAverages.get(analogSensor)
                 .stream()
-                .mapToInt(SensorValues::getRaw)
+                .mapToInt(SensorValues::raw)
                 .average()
-                .orElse(latest.getRaw()))
+                .orElse(latest.raw()))
                 .intValue();
 
-        averagedForTime.setMin(latest.getMin());
-        averagedForTime.setMax(latest.getMax());
-        averagedForTime.setRaw(average);
-        averagedForTime.apply(average);
-
-        return averagedForTime;
+        return new SensorValues()
+                .toBuilder()
+                .recordedOn(sensorValues.recordedOn())
+                .min(latest.min())
+                .max(latest.max())
+                .raw(average)
+                .build()
+                .apply(average);
     }
 
 
 
     /*
     private void applySensorMetrics(AliasView view, AnalogSensor analogSensor, SensorValues averagePacket) {
-        view.getSensors()
-                .put(analogSensor.getName(), Integer.valueOf(averagePacket.getRaw()).doubleValue());
-        view.getSensorMins()
-                .put(analogSensor.getName(), Integer.valueOf(averagePacket.getMin()).doubleValue());
-        view.getSensorMaxes()
-                .put(analogSensor.getName(), Integer.valueOf(averagePacket.getMax()).doubleValue());
-        view.getSensorPercentages()
-                .put(analogSensor.getName(),
+        view.sensors()
+                .put(analogSensor.name(), Integer.valueOf(averagePacket.raw()).doubleValue());
+        view.sensorMins()
+                .put(analogSensor.name(), Integer.valueOf(averagePacket.min()).doubleValue());
+        view.sensorMaxes()
+                .put(analogSensor.name(), Integer.valueOf(averagePacket.max()).doubleValue());
+        view.sensorPercentages()
+                .put(analogSensor.name(),
                             getSensorPercentage(
-                                    averagePacket.getMin(),
-                                averagePacket.getMax(),
-                                averagePacket.getRaw(),
+                                    averagePacket.min(),
+                                averagePacket.max(),
+                                averagePacket.raw(),
                                 analogSensor));
     }
 
@@ -470,11 +471,11 @@ public class SimpleAliasService  {
                 .setScale(2, RoundingMode.HALF_UP)
                 .doubleValue();
 
-        double base = (analogSensor.getFactor() != null && analogSensor.getMode() != null)
-                ? analogSensor.getMode().realPercent(percentage, analogSensor.getFactor())
+        double base = (analogSensor.factor() != null && analogSensor.mode() != null)
+                ? analogSensor.mode().realPercent(percentage, analogSensor.factor())
                 : percentage;
 
-        return analogSensor.isInverted()
+        return analogSensor.inverted()
                 ? 100F - base
                 : base;
     }
@@ -482,15 +483,15 @@ public class SimpleAliasService  {
     public double scaleSensor(AnalogSensor analogSensor, int sensorValue) {
         return sensorValue;
 
-        //double v1 = sensorValue * (analogSensor.getVoltage() / 1023f);
-        //return (analogSensor.getVoltage() - v1) * (analogSensor.getResistance() / v1);
+        //double v1 = sensorValue * (analogSensor.voltage() / 1023f);
+        //return (analogSensor.voltage() - v1) * (analogSensor.resistance() / v1);
     }
 
 
     public Optional<AnalogSensor> getAnalogSensorByPin(Mapping mapping, PinCoordinate coordinate) {
-        return mapping.getAnalogSensors()
+        return mapping.analogSensors()
                 .stream()
-                .filter(analogSensor -> Objects.equals(coordinate.getIdentifier(), analogSensor.getPin()))
+                .filter(analogSensor -> Objects.equals(coordinate.identifier(), analogSensor.pin()))
                 .findFirst();
     }
 
@@ -502,35 +503,28 @@ public class SimpleAliasService  {
             log.info("Setting states:");
             desiredState.forEach((k, v) -> log.info(k+": " + (v ? "true":"false")));
 
-            // TODO: Remove
-            //return cacheBoardDigitalState(boardId, connectorService
-            //        .writeDigital(boardId, identifiers(boardId, desiredState)));
-
-            // NEW
-            Request r = new Request();
-            identifiers(boardId, desiredState)
+            Request r = identifiers(boardId, desiredState)
                     .entrySet()
                     .stream()
                     .map(e -> new DigitalWrite(e.getKey(), e.getValue()))
-                    .forEach(r::digitalWrite);
-            mapping.getAnalogSensors().stream().map(AnalogSensor::asAnalogRead)
-                    .forEach(r::analogRead);
+                    .reduce(Request.empty(), Request::digitalWrite, (a, b) -> a);
+            r = mapping.analogSensors().stream().map(AnalogSensor::asAnalogRead)
+                    .reduce(r, Request::analogRead, (a, b) -> a);
 
             Response response = connectorService.send(boardId, r);
             sendAnalogSensorEvents(mapping, response);
             return cacheBoardState(mapping, response);
         }
-        return new Response();
+        return Response.builder().build();
     }
 
     public Response setupBoard(UUID boardId) throws IOException {
-        Request request = new Request();
-        getMapping(boardId)
-                .getAppliances()
+        Request request = getMapping(boardId)
+                .appliances()
                 .stream()
-                .map(Appliance::getIdentifier)
+                .map(Appliance::identifier)
                 .map(id -> new ModeSet(id, Mode.OUTPUT))
-                .forEach(request::modeSet);
+                .reduce(Request.empty(), Request::modeSet, (a, b) -> a);
         return connectorService.send(boardId, request);
     }
 
@@ -555,33 +549,30 @@ public class SimpleAliasService  {
     public void handleJoystickEvent(JoystickEvent joystickEvent, Mapping mapping) {
         String eventId = joystickEvent.getNumber() + ":" + joystickEvent.getEventValue();
         Optional.of(eventId)
-                .map(mapping.getControlMap()::get)
+                .map(mapping.controlMap()::get)
                 .ifPresent(appliances -> toggleAppliances(mapping, appliances));
     }
 
     private void toggleAppliances(Mapping mapping, List<String> appliances) {
-        Map<Identifier, Boolean> digitalState = currentState(mapping.getConnectorId(), mapping);
+        Map<Identifier, Boolean> digitalState = currentState(mapping.connectorId(), mapping);
         // Whether they should be turned on or not.
-        boolean setStateAs = mapping.getAppliances()
+        boolean setStateAs = mapping.appliances()
                 .stream()
-                .filter(appliance -> appliances.contains(appliance.getName()))
-                .noneMatch(appliance -> digitalState.get(appliance.getIdentifier()));
+                .filter(appliance -> appliances.contains(appliance.name()))
+                .noneMatch(appliance -> digitalState.get(appliance.identifier()));
 
         // Read appliances
-        Request request = mapping.getAppliances()
+        Request request = mapping.appliances()
                 .stream()
-                .filter(appliance -> appliances.contains(appliance.getName()))
+                .filter(appliance -> appliances.contains(appliance.name()))
                 .reduce(
-                        new Request(),
-                        (req, app) -> req.digitalWrite(new DigitalWrite(app.getIdentifier(),
+                        Request.empty(),
+                        (req, app) -> req.digitalWrite(new DigitalWrite(app.identifier(),
                                 DigitalState.fromBoolean(setStateAs))), (a, b) -> a);
-        // Read Analog pins
-        //request.analogRead(mapping.getAnalogSensors().stream().map(AnalogSensor::asAnalogRead));
 
         log.trace(request.toString());
 
-        cacheBoardState(mapping, connectorService.send(mapping.getConnectorId(), request));
-        //cacheBoardDigitalState(mapping.getConnectorId(), connectorService.send(mapping.getConnectorId(), request).getDigital());
+        cacheBoardState(mapping, connectorService.send(mapping.connectorId(), request));
     }
 
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/util/MarkedTimeFrame.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/util/MarkedTimeFrame.java
@@ -2,18 +2,22 @@ package io.freedriver.autonomy.util;
 
 import java.time.Instant;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
 public class MarkedTimeFrame<F> extends TimeFrame {
     private F fieldValue;
 
     public MarkedTimeFrame(Instant start, Instant finish, F fieldValue) {
         super(start, finish);
-    }
-
-    public F getFieldValue() {
-        return fieldValue;
-    }
-
-    public void setFieldValue(F fieldValue) {
         this.fieldValue = fieldValue;
     }
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/util/TimeFrame.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/util/TimeFrame.java
@@ -9,14 +9,22 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
 public class TimeFrame {
     private Instant start;
     private Instant finish;
-
-    public TimeFrame(Instant start, Instant finish) {
-        this.start = start;
-        this.finish = finish;
-    }
 
     public static <T, F> List<MarkedTimeFrame<F>> blocks(Stream<T> stream, Function<T, Instant> whenFunction, Function<T, F> fieldFunction) {
         List<MarkedTimeFrame<F>> timeFrames = new ArrayList<>();
@@ -54,26 +62,10 @@ public class TimeFrame {
         return false;
     }
 
-    public Instant getStart() {
-        return start;
-    }
-
-    public void setStart(Instant start) {
-        this.start = start;
-    }
-
-    public Instant getFinish() {
-        return finish;
-    }
-
-    public void setFinish(Instant finish) {
-        this.finish = finish;
-    }
-    
     public Duration size() {
         return Duration.between(start, finish);
-    } 
-    
+    }
+
     public boolean greaterThan(Duration compare) {
         return size().compareTo(compare) > 0;
     }
@@ -85,5 +77,5 @@ public class TimeFrame {
     public boolean contains(Instant instant) {
         return (getStart().isAfter(instant) && getFinish().isBefore(instant));
     }
-    
+
 }

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageChange.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageChange.java
@@ -13,12 +13,12 @@ import io.freedriver.math.measurement.types.electrical.Potential;
 import io.freedriver.victron.VEDirectMessage;
 
 public enum VEDirectMessageChange {
-    RELAY_STATE("Relay state", VEDirectMessage::getRelayState),
-    STATE_OF_OPERATION("State of operation", VEDirectMessage::getStateOfOperation),
-    TRACKER_OPERATION("Tracker operation", VEDirectMessage::getTrackerOperation),
-    ERROR_CODE("Error code", VEDirectMessage::getErrorCode),
-    OFF_REASON("Off reason", VEDirectMessage::getOffReason),
-    YIELD_YESTERDAY("Yesterday's yield", VEDirectMessage::getYieldYesterday),
+    RELAY_STATE("Relay state", VEDirectMessage::relayState),
+    STATE_OF_OPERATION("State of operation", VEDirectMessage::stateOfOperation),
+    TRACKER_OPERATION("Tracker operation", VEDirectMessage::trackerOperation),
+    ERROR_CODE("Error code", VEDirectMessage::errorCode),
+    OFF_REASON("Off reason", VEDirectMessage::offReason),
+    YIELD_YESTERDAY("Yesterday's yield", VEDirectMessage::yieldYesterday),
     ;
 
     private final String fieldName;

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageLogging.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageLogging.java
@@ -9,12 +9,12 @@ public enum VEDirectMessageLogging {
     PV_POWER {
         @Override
         public String getFieldName(VEDirectMessage vdm) {
-            return "Panel power for "+vdm.getProductType().getProductName() +" ("+vdm.getSerialNumber()+")";
+            return "Panel power for "+vdm.productType().getProductName() +" ("+vdm.serialNumber()+")";
         }
 
         @Override
         public String getMessage(VEDirectMessage vdm) {
-            return vdm.getPanelPower().toString();
+            return vdm.panelPower().toString();
         }
 
         @Override
@@ -22,16 +22,16 @@ public enum VEDirectMessageLogging {
             return Duration.ofSeconds(
                     Math.max(2, Math.min(
                             300,
-                            480-vdm.getPanelPower().divide(2.5).intValue()
+                            480-vdm.panelPower().divide(2.5).intValue()
                     )));
         }
 
         @Override
         public boolean validate(VEDirectMessage vdm) {
             return vdm != null
-                    && vdm.getProductType() != null
-                    && vdm.getProductType().getProductName() != null
-                    && vdm.getSerialNumber() != null;
+                    && vdm.productType() != null
+                    && vdm.productType().getProductName() != null
+                    && vdm.serialNumber() != null;
         }
     },
     ;

--- a/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/vedirect/VEDirectMessageService.java
@@ -85,7 +85,7 @@ public class VEDirectMessageService extends EventCrudService<VEDirectMessage> {
      */
     public Stream<VEDirectMessage> last(VictronDevice device, Duration duration) {
         return select((root, cb) -> Stream.of(
-                cb.equal(root.get(VEDirectMessage_.serialNumber), device.getSerialNumber()),
+                cb.equal(root.get(VEDirectMessage_.serialNumber), device.serialNumber()),
                 cb.ge(root.get(VEDirectMessage_.timestamp), Instant.now().minus(duration).toEpochMilli())
                 ), "for device " + device + " last " + duration.toMillis() + "ms");
     }
@@ -102,7 +102,7 @@ public class VEDirectMessageService extends EventCrudService<VEDirectMessage> {
         CriteriaQuery<VEDirectMessage> cq = cb.createQuery(VEDirectMessage.class);
         Root<VEDirectMessage> root = cq.from(VEDirectMessage.class);
         cq.select(root);
-        cq.where(cb.equal(root.get(VEDirectMessage_.serialNumber), device.getSerialNumber()));
+        cq.where(cb.equal(root.get(VEDirectMessage_.serialNumber), device.serialNumber()));
         return queryStream(cq, "byDevice " + device);
     }
 
@@ -117,7 +117,7 @@ public class VEDirectMessageService extends EventCrudService<VEDirectMessage> {
         CriteriaQuery<Long> cq = cb.createQuery(Long.class);
         Root<VEDirectMessage> root = cq.from(VEDirectMessage.class);
         cq.select(cb.count(root));
-        cq.where(cb.equal(root.get(VEDirectMessage_.serialNumber), device.getSerialNumber()));
+        cq.where(cb.equal(root.get(VEDirectMessage_.serialNumber), device.serialNumber()));
         return Benchmark.bench(() -> entityManager.createQuery(cq).getSingleResult(),
                 "countByDevice {}", device);
     }
@@ -133,7 +133,7 @@ public class VEDirectMessageService extends EventCrudService<VEDirectMessage> {
                     cb.max(root.get(VEDirectMessage_.mainVoltage)),
                     cb.max(root.get(VEDirectMessage_.yieldToday)))
                 .where(cb.and(cb.ge(root.get(VEDirectMessage_.timestamp), getStartOfDay().toEpochMilli()),
-                        cb.equal(root.get(VEDirectMessage_.serialNumber), k.getBase().getSerialNumber())));
+                        cb.equal(root.get(VEDirectMessage_.serialNumber), k.base().serialNumber())));
             Tuple t = entityManager.createQuery(cq)
                     .getSingleResult();
             return new ControllerHistoryView(
@@ -163,7 +163,7 @@ public class VEDirectMessageService extends EventCrudService<VEDirectMessage> {
                     root.get(VEDirectMessage_.offReason),
                     cb.count(root))
                     .where(cb.and(cb.ge(root.get(VEDirectMessage_.timestamp), startOfDay.toEpochMilli()),
-                            cb.equal(root.get(VEDirectMessage_.serialNumber), k.getBase().getSerialNumber())))
+                            cb.equal(root.get(VEDirectMessage_.serialNumber), k.base().serialNumber())))
                     .groupBy(root.get(VEDirectMessage_.stateOfOperation),
                             root.get(VEDirectMessage_.offReason));
             return entityManager.createQuery(cq)
@@ -235,7 +235,7 @@ public class VEDirectMessageService extends EventCrudService<VEDirectMessage> {
             cq.select(veDirectMessageRoot);
             cq.where(cb.and(
                     cb.equal(veDirectMessageRoot.get(VEDirectMessage_.timestamp), lastTimestampQuery),
-                    cb.equal(veDirectMessageRoot.get(VEDirectMessage_.serialNumber), k.getBase().getSerialNumber())));
+                    cb.equal(veDirectMessageRoot.get(VEDirectMessage_.serialNumber), k.base().serialNumber())));
                 return entityManager.createQuery(cq)
                         .setFirstResult(0)
                         .setMaxResults(1)


### PR DESCRIPTION
**Summary**

Lombok-ify autonomy and update it for freedriver records (`@Builder(toBuilder = true)`).

**Depends on** merged/installed [freedriver #16](https://github.com/kazetsukaimiko/freedriver/pull/16). CI installs freedriver from source, so #16 must land first (or be on freedriver master when this builds).

**Changes**

- Freedriver record accessors: `getPin()` → `pin()`, `VEDirectMessage.getPanelPower()` → `panelPower()`, `Request.empty()` instead of `new Request()`, etc.
- Mutations: `toBuilder().field(val).build()` (e.g. Request chaining, SensorValues.apply).
- JPA entities stay classes (Hibernate): `@Getter @Setter @EqualsAndHashCode @ToString @NoArgsConstructor`. `event_value` column mapping kept.
- Views/DTOs (`ControllerView`, `AliasView`, `CacheKey`, `PinCoordinate`, `SensorValues`, …) are records + `@Builder(toBuilder = true)`.

**Verification**

- `mvn -pl quarkus -am compile -DskipTests` → SUCCESS
- `mvn -pl bom,jpa,api -am verify` (CI scope) → SUCCESS