### PR TITLE
Disable Mongo Dev Services for local boot

### DIFF
--- a/quarkus/src/main/resources/application.properties
+++ b/quarkus/src/main/resources/application.properties
@@ -10,6 +10,9 @@ quarkus.hibernate-orm.database.generation=update
 # Liquibase minimal config properties
 # quarkus.liquibase.migrate-at-start=true
 
-# MongoDB (events collection — enable when docker/mongo unit is running)
+# Mongo EventStore is still a stub. Do not start Dev Services or treat
+# a missing local mongod as a boot failure.
+quarkus.mongodb.devservices.enabled=false
+quarkus.mongodb.health.enabled=false
 # quarkus.mongodb.connection-string=mongodb://127.0.0.1:27017
 # quarkus.mongodb.database=autonomy


### PR DESCRIPTION
**Summary**

Mongo EventStore is still a stub. Turn off Quarkus Mongo Dev Services and health so a local H2 + jsonlink run does not depend on Docker/mongod.

Pairs with freedriver #17 (boot without `/dev/serial/by-id`, Identifier JSON numbers for `mappings_v2.json`).

**Verification**

Local `mvn -pl quarkus -am package -DskipTests` after installing freedriver #17 SNAPSHOT.