### PR TITLE
Publish autonomy-mqtt-contract to GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   verify:
@@ -40,3 +41,29 @@ jobs:
       # TODO: switch back to full-reactor `mvn verify` once the VEDirect refactor lands and quarkus builds pass.
       - name: Build, test, and Spotless check
         run: mvn --batch-mode --no-transfer-progress clean verify -pl bom,jpa,api -am
+
+  publish-mqtt-contract:
+    name: Publish mqtt-contract
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout autonomy
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          java-version: '23'
+          distribution: temurin
+          cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Deploy mqtt-contract to GitHub Packages
+        run: mvn --batch-mode --no-transfer-progress -pl mqtt-contract -am deploy -DskipTests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,6 @@ jobs:
           server-password: GITHUB_TOKEN
 
       - name: Deploy mqtt-contract to GitHub Packages
-        run: mvn --batch-mode --no-transfer-progress -pl mqtt-contract -am deploy -DskipTests
+        run: mvn --batch-mode --no-transfer-progress -pl jakarta-bom,3p-bom,mqtt-contract -am deploy -DskipTests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,12 @@ jobs:
 
       # TODO: switch back to full-reactor `mvn verify` once the VEDirect refactor lands and quarkus builds pass.
       - name: Build, test, and Spotless check
-        run: mvn --batch-mode --no-transfer-progress clean verify -pl bom,jpa,api -am
+        run: mvn --batch-mode --no-transfer-progress clean verify -pl bom,jpa,api,mqtt-contract -am
 
   publish-mqtt-contract:
     name: Publish mqtt-contract
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: verify
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -53,16 +54,30 @@ jobs:
       - name: Checkout autonomy
         uses: actions/checkout@v4
 
+      - name: Checkout freedriver
+        uses: actions/checkout@v4
+        with:
+          repository: kazetsukaimiko/freedriver
+          path: freedriver
+
       - name: Set up JDK 23
         uses: actions/setup-java@v4
         with:
           java-version: '23'
           distribution: temurin
           cache: maven
+          cache-dependency-path: |
+            pom.xml
+            freedriver/pom.xml
           server-id: github
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
 
+      - name: Install freedriver SNAPSHOT
+        working-directory: freedriver
+        run: mvn --batch-mode --no-transfer-progress install -DskipTests
+
+      # Parent + jakarta-bom + 3p-bom + mqtt-contract only. Do not deploy quarkus/jpa/api/model.
       - name: Deploy mqtt-contract to GitHub Packages
         run: mvn --batch-mode --no-transfer-progress -pl jakarta-bom,3p-bom,mqtt-contract -am deploy -DskipTests
         env:

--- a/mqtt-contract/pom.xml
+++ b/mqtt-contract/pom.xml
@@ -14,6 +14,10 @@
     <description>Shared MQTT appliance JSON contract (schema + Java records). Lean DTO artifact: no JPA, no jsonlink, no Quarkus.</description>
     <packaging>jar</packaging>
 
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -72,6 +76,24 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                        <configuration>
+                            <flattenMode>oss</flattenMode>
+                            <updatePomFile>true</updatePomFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,4 +111,17 @@
       </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kazetsukaimiko/autonomy</url>
+    </repository>
+    <snapshotRepository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/kazetsukaimiko/autonomy</url>
+    </snapshotRepository>
+  </distributionManagement>
 </project>
+


### PR DESCRIPTION
Part of kazetsukaimiko/freedriver-web#41.

Publishes `io.freedriver.autonomy:autonomy-mqtt-contract:1.0.0-SNAPSHOT` to GitHub Packages on push to master. Flattened POM, Java 21 bytecode so freedriver-web (Java 21) can consume it. No tokens in git (`GITHUB_TOKEN` only).

After merge, @kazetsukaimiko needs to grant the `freedriver-web` repo read access on the new package (user packages are private to the publishing repo until that click).

Does not enable live-commands.