### PR TITLE
Publish autonomy-mqtt-contract to GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,45 @@ jobs:
 
       # TODO: switch back to full-reactor `mvn verify` once the VEDirect refactor lands and quarkus builds pass.
       - name: Build, test, and Spotless check
-        run: mvn --batch-mode --no-transfer-progress clean verify -pl bom,jpa,api -am
+        run: mvn --batch-mode --no-transfer-progress clean verify -pl bom,jpa,api,mqtt-contract -am
+
+  publish-mqtt-contract:
+    name: Publish mqtt-contract
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout autonomy
+        uses: actions/checkout@v4
+
+      - name: Checkout freedriver
+        uses: actions/checkout@v4
+        with:
+          repository: kazetsukaimiko/freedriver
+          path: freedriver
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+          cache: maven
+          cache-dependency-path: |
+            pom.xml
+            freedriver/pom.xml
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Install freedriver SNAPSHOT
+        working-directory: freedriver
+        run: mvn --batch-mode --no-transfer-progress install -DskipTests
+
+      # Parent + jakarta-bom + 3p-bom + mqtt-contract only. Do not deploy quarkus/jpa/api/model.
+      - name: Deploy mqtt-contract to GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn --batch-mode --no-transfer-progress -pl .,jakarta-bom,3p-bom,mqtt-contract deploy -DskipTests

--- a/mqtt-contract/pom.xml
+++ b/mqtt-contract/pom.xml
@@ -14,6 +14,13 @@
     <description>Shared MQTT appliance JSON contract (schema + Java records). Lean DTO artifact: no JPA, no jsonlink, no Quarkus.</description>
     <packaging>jar</packaging>
 
+    <properties>
+        <!-- freedriver-web is Java 21; published bytecode must load on 21. -->
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -74,10 +81,49 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <useModulePath>false</useModulePath>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.7.2</version>
+                <configuration>
+                    <flattenMode>oss</flattenMode>
+                    <updatePomFile>true</updatePomFile>
+                    <pomElements>
+                        <dependencies>resolve</dependencies>
+                        <dependencyManagement>remove</dependencyManagement>
+                        <properties>resolve</properties>
+                        <build>remove</build>
+                        <repositories>remove</repositories>
+                    </pomElements>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -111,4 +111,18 @@
       </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kazetsukaimiko/autonomy</url>
+    </repository>
+    <snapshotRepository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kazetsukaimiko/autonomy</url>
+    </snapshotRepository>
+  </distributionManagement>
+
 </project>


### PR DESCRIPTION
## Summary
- Parent `distributionManagement` deploys to `https://maven.pkg.github.com/kazetsukaimiko/autonomy` (`id` `github`).
- On push to `master`, after verify, deploy **only** parent POM + `autonomy-jakarta-bom` + `autonomy-3p-bom` + `autonomy-mqtt-contract` (`-pl .,jakarta-bom,3p-bom,mqtt-contract`). Does not deploy quarkus/jpa/api/model.
- `mqtt-contract` compiles with `--release 21` so freedriver-web (Java 21) can load the jar. Parent stays Java 23.
- Flatten the published contract POM so consumers do not have to resolve `freedriver-*-bom` SNAPSHOTs (those stay build-time only).
- CI uses `setup-java` `server-id: github` + `GITHUB_ACTOR` / `GITHUB_TOKEN`. No tokens in git.

Verify now also includes `mqtt-contract` so this PR is actually compiled.

## After merge
GitHub Packages for a user-owned repo are not visible to other repos until kaze grants **read** on the package to `kazetsukaimiko/freedriver-web`. That click is required before web CI can resolve the artifact.

## Test plan
- [ ] PR verify builds mqtt-contract with release 21
- [ ] After merge, master publish job deploys the four artifacts
- [ ] No quarkus/jpa/api/model deployed
- [ ] kaze grants freedriver-web read on the new package