### PR TITLE
Publish mqtt-contract as unique 1.0.run_number versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,20 @@ jobs:
         working-directory: freedriver
         run: mvn --batch-mode --no-transfer-progress install -DskipTests
 
+      # Published coordinate: io.freedriver.autonomy:autonomy-mqtt-contract:1.0.<github.run_number>
+      # Unique non-SNAPSHOT so GitHub Packages does not overwrite the same version.
+      # 1.0.0-SNAPSHOT in git is local-only; versions:set is CI workspace only (not committed).
       # Parent + jakarta-bom + 3p-bom + mqtt-contract only. Do not deploy quarkus/jpa/api/model.
+      - name: Set unique mqtt-contract release version
+        run: |
+          NEW_VERSION="1.0.${{ github.run_number }}"
+          echo "Publishing autonomy-mqtt-contract as ${NEW_VERSION} (git SNAPSHOT is local-only)"
+          mvn --batch-mode --no-transfer-progress \
+            org.codehaus.mojo:versions-maven-plugin:2.21.0:set \
+            -DnewVersion="${NEW_VERSION}" \
+            -DgenerateBackupPoms=false \
+            -DprocessAllModules=true
+
       - name: Deploy mqtt-contract to GitHub Packages
         run: mvn --batch-mode --no-transfer-progress -pl jakarta-bom,3p-bom,mqtt-contract -am deploy -DskipTests
         env:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GitHub Packages overwrites `io.freedriver.autonomy:autonomy-mqtt-contract:1.0.0-SNAPSHOT`, so a contract change never produced a new pin-able coordinate.

This PR changes **only** the `publish-mqtt-contract` job on master:

1. `versions-maven-plugin:set` to `1.0.${{ github.run_number }}` in the CI workspace
2. Deploy parent + `jakarta-bom` + `3p-bom` + `mqtt-contract` as today

Poms in git stay `1.0.0-SNAPSHOT` (local builds). SNAPSHOT is not published.

Consumers pin `io.freedriver.autonomy:autonomy-mqtt-contract:1.0.RUN_NUMBER` from `https://maven.pkg.github.com/kazetsukaimiko/autonomy`.

Verified locally (same `-pl` as CI, deploy to a file repo as `1.0.99999`):

- Deployed only parent, jakarta-bom, 3p-bom, mqtt-contract
- No SNAPSHOT, no quarkus/jpa/api/model
- Flattened POM has no parent and concrete compile deps (`jackson-databind:2.22.0`, `jakarta.validation-api:3.1.0`)
- A dummy consumer resolved `autonomy-mqtt-contract:1.0.99999` and its transitives

GitHub Actions `verify` on this PR is green. Publish is master-only (skipped on the PR, as intended).

Does not change MQTT topics, retain, TLS, or live-commands.

Version scheme is documented on the publish job. The freedriver-web consume note still lists `1.0.0-SNAPSHOT` and will need a follow-up after the first unique publish.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5442b202-9664-4497-a4f6-861c3251bae7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5442b202-9664-4497-a4f6-861c3251bae7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

