### PR TITLE
Publish mqtt-contract as YEAR-MONTH_rBUILD_NUM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,20 @@ jobs:
         working-directory: freedriver
         run: mvn --batch-mode --no-transfer-progress install -DskipTests
 
+      # Published coordinate: io.freedriver.autonomy:autonomy-mqtt-contract:1.0.<github.run_number>
+      # Unique non-SNAPSHOT so GitHub Packages does not overwrite the same version.
+      # 1.0.0-SNAPSHOT in git is local-only; versions:set is CI workspace only (not committed).
       # Parent + jakarta-bom + 3p-bom + mqtt-contract only. Do not deploy quarkus/jpa/api/model.
+      - name: Set unique mqtt-contract release version
+        run: |
+          NEW_VERSION="1.0.${{ github.run_number }}"
+          echo "Publishing autonomy-mqtt-contract as ${NEW_VERSION} (git SNAPSHOT is local-only)"
+          mvn --batch-mode --no-transfer-progress \
+            org.codehaus.mojo:versions-maven-plugin:2.21.0:set \
+            -DnewVersion="${NEW_VERSION}" \
+            -DgenerateBackupPoms=false \
+            -DprocessAllModules=true
+
       - name: Deploy mqtt-contract to GitHub Packages
         run: mvn --batch-mode --no-transfer-progress -pl jakarta-bom,3p-bom,mqtt-contract -am deploy -DskipTests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - name: Checkout autonomy
@@ -77,13 +77,18 @@ jobs:
         working-directory: freedriver
         run: mvn --batch-mode --no-transfer-progress install -DskipTests
 
-      # Published coordinate: io.freedriver.autonomy:autonomy-mqtt-contract:1.0.<github.run_number>
+      # Published coordinate: io.freedriver.autonomy:autonomy-mqtt-contract:YEAR-MONTH_rBUILD_NUM
+      # Example: 2026-08_r184 (UTC year-month + github.run_number).
       # Unique non-SNAPSHOT so GitHub Packages does not overwrite the same version.
       # 1.0.0-SNAPSHOT in git is local-only; versions:set is CI workspace only (not committed).
       # Parent + jakarta-bom + 3p-bom + mqtt-contract only. Do not deploy quarkus/jpa/api/model.
+      # After a successful deploy, tag GITHUB_SHA with the same YEAR-MONTH_rBUILD_NUM.
       - name: Set unique mqtt-contract release version
         run: |
-          NEW_VERSION="1.0.${{ github.run_number }}"
+          YEAR="$(date -u +%Y)"
+          MONTH="$(date -u +%m)"
+          NEW_VERSION="${YEAR}-${MONTH}_r${{ github.run_number }}"
+          echo "NEW_VERSION=${NEW_VERSION}" >> "$GITHUB_ENV"
           echo "Publishing autonomy-mqtt-contract as ${NEW_VERSION} (git SNAPSHOT is local-only)"
           mvn --batch-mode --no-transfer-progress \
             org.codehaus.mojo:versions-maven-plugin:2.21.0:set \
@@ -95,3 +100,14 @@ jobs:
         run: mvn --batch-mode --no-transfer-progress -pl jakarta-bom,3p-bom,mqtt-contract -am deploy -DskipTests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag published version
+        run: |
+          if [ -z "${NEW_VERSION}" ]; then
+            echo "NEW_VERSION is empty; refusing to tag"
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${NEW_VERSION}" "${GITHUB_SHA}" -m "${NEW_VERSION}"
+          git push origin "refs/tags/${NEW_VERSION}"

--- a/mqtt-contract/pom.xml
+++ b/mqtt-contract/pom.xml
@@ -96,6 +96,19 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Title>${project.artifactId}</Implementation-Title>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <useModulePath>false</useModulePath>


### PR DESCRIPTION
GitHub Packages overwrites `1.0.0-SNAPSHOT`, so a contract change never produced a pin-able version.

kaze + PM locked **build numbers**, not semver / conventional commits / `1.0.<run_number>`.

Publish job on master only:

1. `versions-maven-plugin:set` to `YEAR-MONTH_rBUILD_NUM` in the CI workspace (UTC `date +%Y-%m` + `github.run_number`, e.g. `2026-08_r184`)
2. Deploy parent + jakarta-bom + 3p-bom + mqtt-contract as today
3. Jar `Implementation-Title` = `autonomy-mqtt-contract`, `Implementation-Version` = the same `YEAR-MONTH_rBUILD_NUM` (`${project.version}` after set)
4. After a successful deploy, annotated-tag `GITHUB_SHA` with that same string and push the tag (`contents: write` on this job only)

Poms in git stay `1.0.0-SNAPSHOT`. SNAPSHOT is not published. Local SNAPSHOT jars keep `Implementation-Version` as `project.version`.

Replaces #26 (opened as kaze, so they cannot approve).

Does not change MQTT topics, retain, TLS, or live-commands.