### PR TITLE
Align autonomy with jsonlink List discovery and AliasView factory

### DIFF
--- a/model/src/main/java/io/freedriver/autonomy/jaxrs/view/AliasView.java
+++ b/model/src/main/java/io/freedriver/autonomy/jaxrs/view/AliasView.java
@@ -4,9 +4,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder(toBuilder = true)
+@Builder(toBuilder = true, access = AccessLevel.PUBLIC)
 public record AliasView(
         Map<String, Boolean> applianceStates,
         Map<String, Boolean> groupStates,
@@ -28,5 +29,10 @@ public record AliasView(
 
     public AliasView() {
         this(null, null, null, null, null, null, null);
+    }
+
+    public static AliasView of(
+            Map<String, Boolean> applianceStates, Map<String, Boolean> groupStates) {
+        return new AliasView(applianceStates, groupStates, null, null, null, null, null);
     }
 }

--- a/model/src/main/java/io/freedriver/autonomy/jaxrs/view/AliasView.java
+++ b/model/src/main/java/io/freedriver/autonomy/jaxrs/view/AliasView.java
@@ -4,10 +4,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder(toBuilder = true, access = AccessLevel.PUBLIC)
+@Builder(toBuilder = true)
 public record AliasView(
         Map<String, Boolean> applianceStates,
         Map<String, Boolean> groupStates,

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,15 @@
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.14.0</version>
+          <configuration>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+              </path>
+            </annotationProcessorPaths>
+          </configuration>
         </plugin>
         <!-- Spotless: enforces import order and removes unused imports -->
         <plugin>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -127,6 +127,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.freedriver.autonomy</groupId>
+            <artifactId>autonomy-model</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
             <version>4.8.162</version>
@@ -158,6 +163,16 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/quarkus/src/main/java/io/freedriver/autonomy/events/VEDirectEventSource.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/events/VEDirectEventSource.java
@@ -78,7 +78,7 @@ public class VEDirectEventSource implements EventSource {
     }
 
     private void discoverNow() {
-        connectionManager.discover(this::isVictronCable).toList().forEach(this::ensureReader);
+        connectionManager.discover(this::isVictronCable).forEach(this::ensureReader);
     }
 
     private void discoveryLoop() {

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorServiceCommon.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/ConnectorServiceCommon.java
@@ -59,7 +59,7 @@ public class ConnectorServiceCommon {
 
         // Connect new. Match by canonical path so /dev/serial/by-id/... and /dev/ttyACM0
         // are not opened twice against the same Arduino.
-        List<CompletableFuture<Void>> threads = Connectors.allDevices()
+        List<CompletableFuture<Void>> threads = Connectors.allDevices().stream()
                 .filter(device -> ACTIVE_CONNECTORS.stream()
                         .noneMatch(existing -> sameDevice(existing, device)))
                 .map(device -> Connectors.findOrOpenAndConsume(device, executorService, ACTIVE_CONNECTORS::add))

--- a/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
+++ b/quarkus/src/main/java/io/freedriver/autonomy/service/SimpleAliasService.java
@@ -405,10 +405,7 @@ public class SimpleAliasService  {
 
          */
 
-        return AliasView.builder()
-                .applianceStates(applianceStates)
-                .groupStates(groupStates)
-                .build();
+        return AliasView.of(applianceStates, groupStates);
     }
 
 
@@ -518,7 +515,7 @@ public class SimpleAliasService  {
             sendAnalogSensorEvents(mapping, response);
             return cacheBoardState(mapping, response);
         }
-        return Response.builder().build();
+        return Response.empty();
     }
 
     public Response setupBoard(UUID boardId) throws IOException {


### PR DESCRIPTION
## Summary
- `Connectors.allDevices()` and `SerialConnectionManager.discover()` now return `List`; drop leftover `.toList()` / add `.stream()`.
- Public `AliasView.of` and `Response.empty()` so quarkus does not call lombok builders generated in other modules.
- Direct `autonomy-model` dependency and lombok `annotationProcessorPaths` on the compiler plugin.

Supersedes #31 (reopened as kazetsukaiyuni so @kazetsukaimiko can review and merge).

Depends on https://github.com/kazetsukaimiko/freedriver/pull/22

## Test plan
- [x] `mvn -pl quarkus -am clean package -DskipTests`
- [x] Deployed with the matching freedriver snapshot; `/rest/simple/` returned the Mega UUID